### PR TITLE
test: expand test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Thumbs.db
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
         "@eslint/js": "^10.0.1",
+        "@vitest/coverage-v8": "^4.1.2",
         "eslint": "^10.2.0",
         "globals": "^17.4.0",
         "husky": "^9.1.7",
@@ -80,6 +81,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
@@ -88,6 +99,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -1233,6 +1284,37 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -1454,6 +1536,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -2335,6 +2436,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -2347,6 +2458,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -2504,6 +2622,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -3075,6 +3232,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdn-data": {
@@ -3675,6 +3860,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npm run build --workspaces",
     "clean": "npm run clean --workspaces",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "lint": "eslint packages/core/loadgo.js packages/core/loadgo-vanilla.js scripts/ examples/ packages/core/tests/",
     "lint:fix": "eslint --fix packages/core/loadgo.js packages/core/loadgo-vanilla.js scripts/ examples/ packages/core/tests/",
@@ -17,12 +18,15 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.js": ["prettier --write"]
+    "*.js": [
+      "prettier --write"
+    ]
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^10.0.1",
+    "@vitest/coverage-v8": "^4.1.2",
     "eslint": "^10.2.0",
     "globals": "^17.4.0",
     "husky": "^9.1.7",

--- a/packages/core/tests/loadgo-vanilla.test.js
+++ b/packages/core/tests/loadgo-vanilla.test.js
@@ -605,3 +605,129 @@ describe('JS - resetprogress on uninitialized element', () => {
     document.body.removeChild(fresh)
   })
 })
+
+describe('JS - Filter init CSS', () => {
+  it('hue-rotate filter sets hue-rotate(360deg) on image', () => {
+    Loadgo.init(image, { filter: 'hue-rotate' })
+    expect(image.style.filter).toBe('hue-rotate(360deg)')
+  })
+
+  it('opacity filter sets opacity(0) on image', () => {
+    Loadgo.init(image, { filter: 'opacity' })
+    expect(image.style.filter).toBe('opacity(0)')
+  })
+
+  it('grayscale filter sets grayscale(1) on image', () => {
+    Loadgo.init(image, { filter: 'grayscale' })
+    expect(image.style.filter).toBe('grayscale(1)')
+  })
+
+  it('filter with animated: true sets transition on image', () => {
+    Loadgo.init(image, { filter: 'blur', animated: true })
+    expect(image.style.transition).toContain('filter')
+  })
+})
+
+describe('JS - setprogress in filter mode', () => {
+  it('hue-rotate at 50% sets hue-rotate(180deg)', () => {
+    Loadgo.init(image, { filter: 'hue-rotate' })
+    Loadgo.setprogress(image, 50)
+    expect(image.style.filter).toBe('hue-rotate(180deg)')
+  })
+
+  it('opacity at 50% sets opacity(0.5)', () => {
+    Loadgo.init(image, { filter: 'opacity' })
+    Loadgo.setprogress(image, 50)
+    expect(image.style.filter).toBe('opacity(0.5)')
+  })
+
+  it('grayscale at 50% sets grayscale(0.5)', () => {
+    Loadgo.init(image, { filter: 'grayscale' })
+    Loadgo.setprogress(image, 50)
+    expect(image.style.filter).toBe('grayscale(0.5)')
+  })
+})
+
+describe('JS - setprogress: direction rl', () => {
+  it('setprogress with direction rl stores progress', () => {
+    Loadgo.init(image, { direction: 'rl' })
+    Loadgo.setprogress(image, 50)
+    expect(Loadgo.getprogress(image)).toBe(50)
+  })
+
+  it('setprogress with direction rl sets overlay width proportionally', () => {
+    Loadgo.init(image, { direction: 'rl', animated: false })
+    Loadgo.options(image).width = 100
+    Loadgo.setprogress(image, 25)
+    expect(getOverlay().style.width).toBe('75px')
+  })
+})
+
+describe('JS - image option background position', () => {
+  it('image + lr direction uses 100% 0% background-position', () => {
+    Loadgo.init(image, { image: 'logo.png', direction: 'lr' })
+    expect(getOverlay().style.backgroundPosition).toBe('100% 0%')
+  })
+
+  it('image + rl direction uses 0% 50% background-position', () => {
+    Loadgo.init(image, { image: 'logo.png', direction: 'rl' })
+    expect(getOverlay().style.backgroundPosition).toBe('0% 50%')
+  })
+
+  it('image + bt direction uses 100% 0% background-position', () => {
+    Loadgo.init(image, { image: 'logo.png', direction: 'bt' })
+    expect(getOverlay().style.backgroundPosition).toBe('100% 0%')
+  })
+
+  it('image + tb direction uses 0% 100% background-position', () => {
+    Loadgo.init(image, { image: 'logo.png', direction: 'tb' })
+    expect(getOverlay().style.backgroundPosition).toBe('0% 100%')
+  })
+})
+
+describe('JS - options() update after init', () => {
+  it('options() with args after init merges into existing options', () => {
+    Loadgo.init(image, { bgcolor: '#FF0000' })
+    Loadgo.options(image, { bgcolor: '#00FF00' })
+    expect(Loadgo.options(image).bgcolor).toBe('#00FF00')
+  })
+
+  it('options() update preserves previously set options', () => {
+    Loadgo.init(image, { bgcolor: '#FF0000', opacity: 0.8 })
+    Loadgo.options(image, { bgcolor: '#00FF00' })
+    expect(Loadgo.options(image).opacity).toBe(0.8)
+  })
+})
+
+describe('JS - loop/stop edge cases', () => {
+  it('loop() on uninitialized element does not throw', () => {
+    expect(() => Loadgo.loop(image, 1000)).not.toThrow()
+  })
+
+  it('loop() while already looping does not throw', () => {
+    Loadgo.init(image)
+    Loadgo.loop(image, 1000)
+    expect(() => Loadgo.loop(image, 1000)).not.toThrow()
+    Loadgo.stop(image)
+  })
+
+  it('stop() on uninitialized element does not throw', () => {
+    expect(() => Loadgo.stop(image)).not.toThrow()
+  })
+
+  it('destroy() while looping stops the interval', () => {
+    vi.useFakeTimers()
+    try {
+      let callCount = 0
+      Loadgo.init(image, { onProgress: () => callCount++ })
+      Loadgo.loop(image, 100)
+      vi.advanceTimersByTime(300)
+      const countBeforeDestroy = callCount
+      Loadgo.destroy(image)
+      vi.advanceTimersByTime(300)
+      expect(callCount).toBe(countBeforeDestroy)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/core/tests/loadgo-vanilla.test.js
+++ b/packages/core/tests/loadgo-vanilla.test.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
-import { beforeAll, beforeEach, afterEach, describe, it, expect } from 'vitest'
+import { beforeAll, beforeEach, afterEach, describe, it, expect, vi } from 'vitest'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const scriptCode = readFileSync(join(__dirname, '../loadgo-vanilla.js'), 'utf8')
@@ -434,5 +434,180 @@ describe('JS - Resize listener cleanup', () => {
     Loadgo.init(image)
     Loadgo.destroy(image)
     expect(() => window.dispatchEvent(new Event('resize'))).not.toThrow()
+  })
+})
+
+describe('JS - setprogress: direction bt', () => {
+  it('setprogress with direction bt does not throw', () => {
+    Loadgo.init(image, { direction: 'bt' })
+    expect(() => Loadgo.setprogress(image, 50)).not.toThrow()
+  })
+
+  it('setprogress with direction bt stores progress', () => {
+    Loadgo.init(image, { direction: 'bt' })
+    Loadgo.setprogress(image, 50)
+    expect(Loadgo.getprogress(image)).toBe(50)
+  })
+
+  it('setprogress with direction bt sets overlay height proportionally', () => {
+    Loadgo.init(image, { direction: 'bt', animated: false })
+    // Patch stored height since jsdom has no layout engine
+    Loadgo.options(image).height = 200
+    Loadgo.setprogress(image, 25)
+    expect(getOverlay().style.height).toBe('150px')
+  })
+
+  it('setprogress with direction bt does not modify overlay width', () => {
+    Loadgo.init(image, { direction: 'bt', animated: false })
+    const widthBefore = getOverlay().style.width
+    Loadgo.setprogress(image, 50)
+    expect(getOverlay().style.width).toBe(widthBefore)
+  })
+})
+
+describe('JS - setprogress: direction tb', () => {
+  it('setprogress with direction tb does not throw', () => {
+    Loadgo.init(image, { direction: 'tb' })
+    expect(() => Loadgo.setprogress(image, 50)).not.toThrow()
+  })
+
+  it('setprogress with direction tb stores progress', () => {
+    Loadgo.init(image, { direction: 'tb' })
+    Loadgo.setprogress(image, 50)
+    expect(Loadgo.getprogress(image)).toBe(50)
+  })
+
+  it('setprogress with direction tb sets overlay height and top', () => {
+    Loadgo.init(image, { direction: 'tb', animated: false })
+    Loadgo.options(image).height = 200
+    Loadgo.setprogress(image, 25)
+    expect(getOverlay().style.height).toBe('150px')
+    expect(getOverlay().style.top).toBe('50px')
+  })
+})
+
+describe('JS - setprogress: boundary values', () => {
+  it('setprogress(0) stores 0', () => {
+    Loadgo.init(image)
+    Loadgo.setprogress(image, 0)
+    expect(Loadgo.getprogress(image)).toBe(0)
+  })
+
+  it('setprogress(100) stores 100', () => {
+    Loadgo.init(image)
+    Loadgo.setprogress(image, 100)
+    expect(Loadgo.getprogress(image)).toBe(100)
+  })
+
+  it('setprogress(0) sets overlay width to full width', () => {
+    Loadgo.init(image, { animated: false })
+    Loadgo.options(image).width = 100
+    Loadgo.setprogress(image, 0)
+    expect(getOverlay().style.width).toBe('100px')
+  })
+
+  it('setprogress(100) sets overlay width to 0', () => {
+    Loadgo.init(image, { animated: false })
+    Loadgo.options(image).width = 100
+    Loadgo.setprogress(image, 100)
+    expect(getOverlay().style.width).toBe('0px')
+  })
+})
+
+describe('JS - loop restart after stop', () => {
+  it('loop() can be called again after stop() without error', () => {
+    Loadgo.init(image)
+    Loadgo.loop(image, 1000)
+    Loadgo.stop(image)
+    expect(() => {
+      Loadgo.loop(image, 1000)
+      Loadgo.stop(image)
+    }).not.toThrow()
+  })
+})
+
+describe('JS - onProgress during loop', () => {
+  it('onProgress is called on each loop tick', () => {
+    vi.useFakeTimers()
+    try {
+      let callCount = 0
+      Loadgo.init(image, { onProgress: () => callCount++ })
+      Loadgo.loop(image, 100)
+      vi.advanceTimersByTime(350) // fires at 100ms, 200ms, 300ms → 3 ticks
+      Loadgo.stop(image)
+      expect(callCount).toBeGreaterThanOrEqual(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('JS - destroy/init lifecycle', () => {
+  it('destroy then re-init resets progress and restores DOM structure', () => {
+    Loadgo.init(image)
+    Loadgo.setprogress(image, 75)
+    Loadgo.destroy(image)
+    Loadgo.init(image)
+    expect(Loadgo.getprogress(image)).toBe(0)
+    expect(image.parentElement.classList.contains('loadgo-container')).toBe(true)
+    expect(image.parentElement.querySelectorAll('.loadgo-overlay').length).toBe(1)
+  })
+
+  it('custom resize listener from before destroy is not called after re-init', () => {
+    let count = 0
+    Loadgo.init(image, { resize: () => count++ })
+    window.dispatchEvent(new Event('resize'))
+    expect(count).toBe(1)
+    Loadgo.destroy(image)
+    Loadgo.init(image) // fresh init without custom resize
+    window.dispatchEvent(new Event('resize'))
+    expect(count).toBe(1) // original custom resize not re-attached
+  })
+})
+
+describe('JS - Multiple elements', () => {
+  it('setprogress on one element does not affect another', () => {
+    const image2 = document.createElement('img')
+    image2.id = 'id-logo-2'
+    document.body.appendChild(image2)
+    Loadgo.init(image)
+    Loadgo.init(image2)
+    Loadgo.setprogress(image, 60)
+    expect(Loadgo.getprogress(image2)).toBe(0)
+    Loadgo.destroy(image2)
+  })
+
+  it('two elements without id can be initialized simultaneously without overwriting each other', () => {
+    const imgA = document.createElement('img') // no id — will get auto-generated one
+    const imgB = document.createElement('img') // no id — will get a different auto-generated one
+    document.body.appendChild(imgA)
+    document.body.appendChild(imgB)
+    Loadgo.init(imgA)
+    Loadgo.init(imgB)
+    Loadgo.setprogress(imgA, 40)
+    expect(Loadgo.getprogress(imgA)).toBe(40)
+    expect(Loadgo.getprogress(imgB)).toBe(0)
+    Loadgo.destroy(imgA)
+    Loadgo.destroy(imgB)
+  })
+})
+
+describe('JS - options() before init()', () => {
+  it('options() called before init() returns undefined', () => {
+    const fresh = document.createElement('img')
+    fresh.id = 'fresh-img'
+    document.body.appendChild(fresh)
+    expect(Loadgo.options(fresh)).toBeUndefined()
+    document.body.removeChild(fresh)
+  })
+})
+
+describe('JS - resetprogress on uninitialized element', () => {
+  it('resetprogress does not throw on an uninitialized element', () => {
+    const fresh = document.createElement('img')
+    fresh.id = 'fresh-img'
+    document.body.appendChild(fresh)
+    expect(() => Loadgo.resetprogress(fresh)).not.toThrow()
+    document.body.removeChild(fresh)
   })
 })

--- a/packages/core/tests/loadgo-vanilla.test.js
+++ b/packages/core/tests/loadgo-vanilla.test.js
@@ -1,16 +1,10 @@
-import { readFileSync } from 'fs'
-import { dirname, join } from 'path'
-import { fileURLToPath } from 'url'
 import { beforeAll, beforeEach, afterEach, describe, it, expect, vi } from 'vitest'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const scriptCode = readFileSync(join(__dirname, '../loadgo-vanilla.js'), 'utf8')
 
 let Loadgo
 let container, image
 
-beforeAll(() => {
-  ;(0, globalThis.eval)(scriptCode)
+beforeAll(async () => {
+  await import('../loadgo-vanilla.js')
   Loadgo = globalThis.Loadgo
 })
 

--- a/packages/core/tests/loadgo.test.js
+++ b/packages/core/tests/loadgo.test.js
@@ -1,18 +1,12 @@
-import { readFileSync } from 'fs'
-import { dirname, join } from 'path'
-import { fileURLToPath } from 'url'
 import { beforeAll, beforeEach, afterEach, describe, it, expect, vi } from 'vitest'
 import $ from 'jquery'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const scriptCode = readFileSync(join(__dirname, '../loadgo.js'), 'utf8')
-
 let $container, $image
 
-beforeAll(() => {
+beforeAll(async () => {
   globalThis.jQuery = $
   globalThis.$ = $
-  ;(0, globalThis.eval)(scriptCode)
+  await import('../loadgo.js')
 })
 
 beforeEach(() => {

--- a/packages/core/tests/loadgo.test.js
+++ b/packages/core/tests/loadgo.test.js
@@ -576,3 +576,133 @@ describe('jQuery - options() before init()', () => {
     $fresh.remove()
   })
 })
+
+describe('jQuery - Unknown method', () => {
+  it('throws for an unknown method name', () => {
+    $image.loadgo()
+    expect(() => $image.loadgo('unknownMethod')).toThrow(/does not exist/)
+  })
+})
+
+describe('jQuery - Multiple img selector', () => {
+  it('throws if selector matches multiple img elements', () => {
+    const $img2 = $('<img id="img-b" />')
+    $('body').append($img2)
+    expect(() => $('img').loadgo()).toThrow()
+    $img2.remove()
+  })
+})
+
+describe('jQuery - Filter init CSS', () => {
+  it('hue-rotate filter sets hue-rotate(360deg) on image', () => {
+    $image.loadgo({ filter: 'hue-rotate' })
+    expect($image[0].style.filter).toBe('hue-rotate(360deg)')
+  })
+
+  it('opacity filter sets opacity(0) on image', () => {
+    $image.loadgo({ filter: 'opacity' })
+    expect($image[0].style.filter).toBe('opacity(0)')
+  })
+
+  it('grayscale filter sets grayscale(1) on image', () => {
+    $image.loadgo({ filter: 'grayscale' })
+    expect($image[0].style.filter).toBe('grayscale(1)')
+  })
+
+  it('filter with animated: true sets transition on image', () => {
+    $image.loadgo({ filter: 'blur', animated: true })
+    expect($image[0].style.transition).toContain('filter')
+  })
+})
+
+describe('jQuery - setprogress in filter mode', () => {
+  it('hue-rotate at 50% sets hue-rotate(180deg)', () => {
+    $image.loadgo({ filter: 'hue-rotate' })
+    $image.loadgo('setprogress', 50)
+    expect($image[0].style.filter).toBe('hue-rotate(180deg)')
+  })
+
+  it('opacity at 50% sets opacity(0.5)', () => {
+    $image.loadgo({ filter: 'opacity' })
+    $image.loadgo('setprogress', 50)
+    expect($image[0].style.filter).toBe('opacity(0.5)')
+  })
+
+  it('grayscale at 50% sets grayscale(0.5)', () => {
+    $image.loadgo({ filter: 'grayscale' })
+    $image.loadgo('setprogress', 50)
+    expect($image[0].style.filter).toBe('grayscale(0.5)')
+  })
+})
+
+describe('jQuery - setprogress: direction rl', () => {
+  it('setprogress with direction rl stores progress', () => {
+    $image.loadgo({ direction: 'rl' })
+    $image.loadgo('setprogress', 50)
+    expect($image.loadgo('getprogress')).toBe(50)
+  })
+
+  it('setprogress with direction rl sets overlay width proportionally', () => {
+    $image.loadgo({ direction: 'rl', animated: false })
+    const data = $image.data('loadgo')
+    data.width = 100
+    $image.data('loadgo', data)
+    $image.loadgo('setprogress', 25)
+    expect(getOverlay()[0].style.width).toBe('75px')
+  })
+})
+
+describe('jQuery - image option background position', () => {
+  it('image + lr direction uses 100% 0% background-position', () => {
+    $image.loadgo({ image: 'logo.png', direction: 'lr' })
+    expect(getOverlay()[0].style.backgroundPosition).toBe('100% 0%')
+  })
+
+  it('image + rl direction uses 0% 50% background-position', () => {
+    $image.loadgo({ image: 'logo.png', direction: 'rl' })
+    expect(getOverlay()[0].style.backgroundPosition).toBe('0% 50%')
+  })
+
+  it('image + bt direction uses 100% 0% background-position', () => {
+    $image.loadgo({ image: 'logo.png', direction: 'bt' })
+    expect(getOverlay()[0].style.backgroundPosition).toBe('100% 0%')
+  })
+
+  it('image + tb direction uses 0% 100% background-position', () => {
+    $image.loadgo({ image: 'logo.png', direction: 'tb' })
+    expect(getOverlay()[0].style.backgroundPosition).toBe('0% 100%')
+  })
+})
+
+describe('jQuery - loop/stop edge cases', () => {
+  it('loop() on uninitialized element does not throw', () => {
+    expect(() => $image.loadgo('loop', 1000)).not.toThrow()
+  })
+
+  it('loop() while already looping does not throw', () => {
+    $image.loadgo()
+    $image.loadgo('loop', 1000)
+    expect(() => $image.loadgo('loop', 1000)).not.toThrow()
+    $image.loadgo('stop')
+  })
+
+  it('stop() on uninitialized element does not throw', () => {
+    expect(() => $image.loadgo('stop')).not.toThrow()
+  })
+
+  it('destroy() while looping stops the interval', () => {
+    vi.useFakeTimers()
+    try {
+      let callCount = 0
+      $image.loadgo({ onProgress: () => callCount++ })
+      $image.loadgo('loop', 100)
+      vi.advanceTimersByTime(300)
+      const countBeforeDestroy = callCount
+      $image.loadgo('destroy')
+      vi.advanceTimersByTime(300)
+      expect(callCount).toBe(countBeforeDestroy)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/core/tests/loadgo.test.js
+++ b/packages/core/tests/loadgo.test.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
-import { beforeAll, beforeEach, afterEach, describe, it, expect } from 'vitest'
+import { beforeAll, beforeEach, afterEach, describe, it, expect, vi } from 'vitest'
 import $ from 'jquery'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -423,5 +423,162 @@ describe('jQuery - Resize listener cleanup', () => {
     $image.loadgo()
     $image.loadgo('destroy')
     expect(() => $(window).trigger('resize')).not.toThrow()
+  })
+})
+
+describe('jQuery - setprogress: direction bt', () => {
+  it('setprogress with direction bt does not throw', () => {
+    $image.loadgo({ direction: 'bt' })
+    expect(() => $image.loadgo('setprogress', 50)).not.toThrow()
+  })
+
+  it('setprogress with direction bt stores progress', () => {
+    $image.loadgo({ direction: 'bt' })
+    $image.loadgo('setprogress', 50)
+    expect($image.loadgo('getprogress')).toBe(50)
+  })
+
+  it('setprogress with direction bt sets overlay height proportionally', () => {
+    $image.loadgo({ direction: 'bt', animated: false })
+    // Patch stored height since jsdom has no layout engine
+    const data = $image.data('loadgo')
+    data.height = 200
+    $image.data('loadgo', data)
+    $image.loadgo('setprogress', 25)
+    expect(getOverlay()[0].style.height).toBe('150px')
+  })
+
+  it('setprogress with direction bt does not modify overlay width', () => {
+    $image.loadgo({ direction: 'bt', animated: false })
+    const widthBefore = getOverlay()[0].style.width
+    $image.loadgo('setprogress', 50)
+    expect(getOverlay()[0].style.width).toBe(widthBefore)
+  })
+})
+
+describe('jQuery - setprogress: direction tb', () => {
+  it('setprogress with direction tb does not throw', () => {
+    $image.loadgo({ direction: 'tb' })
+    expect(() => $image.loadgo('setprogress', 50)).not.toThrow()
+  })
+
+  it('setprogress with direction tb stores progress', () => {
+    $image.loadgo({ direction: 'tb' })
+    $image.loadgo('setprogress', 50)
+    expect($image.loadgo('getprogress')).toBe(50)
+  })
+
+  it('setprogress with direction tb sets overlay height and top', () => {
+    $image.loadgo({ direction: 'tb', animated: false })
+    const data = $image.data('loadgo')
+    data.height = 200
+    $image.data('loadgo', data)
+    $image.loadgo('setprogress', 25)
+    expect(getOverlay()[0].style.height).toBe('150px')
+    expect(getOverlay()[0].style.top).toBe('50px')
+  })
+})
+
+describe('jQuery - setprogress: boundary values', () => {
+  it('setprogress(0) stores 0', () => {
+    $image.loadgo()
+    $image.loadgo('setprogress', 0)
+    expect($image.loadgo('getprogress')).toBe(0)
+  })
+
+  it('setprogress(100) stores 100', () => {
+    $image.loadgo()
+    $image.loadgo('setprogress', 100)
+    expect($image.loadgo('getprogress')).toBe(100)
+  })
+
+  it('setprogress(0) sets overlay width to full width', () => {
+    $image.loadgo({ animated: false })
+    const data = $image.data('loadgo')
+    data.width = 100
+    $image.data('loadgo', data)
+    $image.loadgo('setprogress', 0)
+    expect(getOverlay()[0].style.width).toBe('100px')
+  })
+
+  it('setprogress(100) sets overlay width to 0', () => {
+    $image.loadgo({ animated: false })
+    const data = $image.data('loadgo')
+    data.width = 100
+    $image.data('loadgo', data)
+    $image.loadgo('setprogress', 100)
+    expect(getOverlay()[0].style.width).toBe('0px')
+  })
+})
+
+describe('jQuery - loop restart after stop', () => {
+  it('loop() can be called again after stop() without error', () => {
+    $image.loadgo()
+    $image.loadgo('loop', 1000)
+    $image.loadgo('stop')
+    expect(() => {
+      $image.loadgo('loop', 1000)
+      $image.loadgo('stop')
+    }).not.toThrow()
+  })
+})
+
+describe('jQuery - onProgress during loop', () => {
+  it('onProgress is called on each loop tick', () => {
+    vi.useFakeTimers()
+    try {
+      let callCount = 0
+      $image.loadgo({ onProgress: () => callCount++ })
+      $image.loadgo('loop', 100)
+      vi.advanceTimersByTime(350) // fires at 100ms, 200ms, 300ms → 3 ticks
+      $image.loadgo('stop')
+      expect(callCount).toBeGreaterThanOrEqual(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('jQuery - destroy/init lifecycle', () => {
+  it('destroy then re-init resets progress and restores DOM structure', () => {
+    $image.loadgo()
+    $image.loadgo('setprogress', 75)
+    $image.loadgo('destroy')
+    $image.loadgo()
+    expect($image.loadgo('getprogress')).toBe(0)
+    expect($image.parent().hasClass('loadgo-container')).toBe(true)
+    expect($image.siblings('.loadgo-overlay').length).toBe(1)
+  })
+
+  it('custom resize listener from before destroy is not called after re-init', () => {
+    let count = 0
+    $image.loadgo({ resize: () => count++ })
+    $(window).trigger('resize')
+    expect(count).toBe(1)
+    $image.loadgo('destroy')
+    $image.loadgo() // fresh init without custom resize
+    $(window).trigger('resize')
+    expect(count).toBe(1) // original custom resize not re-attached
+  })
+})
+
+describe('jQuery - Multiple elements', () => {
+  it('setprogress on one element does not affect another', () => {
+    const $image2 = $('<img id="id-logo-2" />')
+    $('body').append($image2)
+    $image.loadgo()
+    $image2.loadgo()
+    $image.loadgo('setprogress', 60)
+    expect($image2.loadgo('getprogress')).toBe(0)
+    $image2.loadgo('destroy')
+  })
+})
+
+describe('jQuery - options() before init()', () => {
+  it('options() called before init() throws because internal data is not set', () => {
+    const $fresh = $('<img id="fresh-img" />')
+    $('body').append($fresh)
+    expect(() => $fresh.loadgo('options')).toThrow()
+    $fresh.remove()
   })
 })

--- a/packages/core/vitest.config.js
+++ b/packages/core/vitest.config.js
@@ -3,5 +3,10 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    coverage: {
+      provider: 'v8',
+      include: ['loadgo.js', 'loadgo-vanilla.js'],
+      reporter: ['text', 'html'],
+    },
   },
 })


### PR DESCRIPTION
Close https://github.com/franverona/loadgo/issues/19

Direction/axis gaps
- bt and tb directions: verify no crash, correct progress storage, and that the right CSS properties (height, top)
are updated — not width. Height calculations are verified with patched dimensions (necessary since jsdom has no
layout engine).

Boundary values
- setprogress(0) and setprogress(100) assert both stored value and overlay pixel dimensions.

Bug-revealing: loop() → stop() → loop() again
- Both jQuery and vanilla: verifies the stale-interval fix (vanilla sets interval = null after clearInterval)
holds.

Callback: onProgress during loop ticks
- Uses vi.useFakeTimers() to advance time 350ms and assert the callback fired on each tick.

Lifecycle: destroy() → init() full cycle
- Verifies progress resets, DOM is rebuilt cleanly, and the old resize listener is not re-attached.

Multiple elements
- jQuery: setprogress on one element doesn't bleed into another.
- Vanilla: same, plus a dedicated test for two id-less elements confirming the auto-generated ID mechanism prevents
  state collision.

Options gaps
- jQuery options() before init() throws (internal data not yet seeded).
- Vanilla options() before init() returns undefined (no-op).
- Vanilla resetprogress() on uninitialized element doesn't throw.

38 new tests added across 12 new describe blocks:
  - Filter init CSS — hue-rotate(360deg), opacity(0), grayscale(1) initial values, and animated: true sets transition on the image
  - Filter setprogress math — verifies the per-filter math: hue-rotate(180deg) at 50%, opacity(0.5) at 50%, grayscale(0.5) at 50%
  - Direction rl setprogress — width calculated correctly (same formula as lr but separate branch)
  - Image background-position by direction — rl → 0% 50%, bt → 100% 0%, tb → 0% 100%
  - loop/stop edge cases — loop on uninitialized, loop while already looping, stop on uninitialized, destroy-while-looping stops the interval
  - Unknown method throws (jQuery) — API contract for invalid method names
  - Multiple element selector throws (jQuery) — $('img').loadgo() when multiple imgs exist
  - options() update path (vanilla) — calling Loadgo.options(el, {...}) after init merges without clobbering