### PR TITLE
feat: custom dom events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
       - '**.gif'
       - '**.png'
   pull_request:
-    branches: [main]
     paths-ignore:
       - '**.md'
       - 'LICENSE'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,17 @@ Two independent parallel implementations in `packages/core/`, both with identica
 - Prettier: single quotes, no semicolons, 2-space indent, trailing commas, 100-char print width
 - `"type": "module"` in root `package.json` — all config files and scripts use ESM
 
+## Custom events
+
+Both implementations dispatch native DOM `CustomEvent`s (not jQuery `.trigger()`). This ensures listeners registered via `addEventListener` work in both versions.
+
+**Implementation rules that are not obvious from the code:**
+
+- `dispatchCustomEvent` requires a raw DOM element. In jQuery plugin methods, `this` is a jQuery wrapper — always use `this[0]` (or `$this[0]` / `rawElement`). The `_setprogress` helper in `loadgo.js` normalises via `const rawElement = $element[0]` for this reason.
+- `resetprogress` and `stop` call `_setprogress(..., false)` (`shouldEmit = false`) and then dispatch their own events (`loadgo:reset` / `loadgo:stop`). This prevents `loadgo:progress` from firing alongside them.
+- `loadgo:complete` is guarded by `!data.interval` — it never fires inside a loop even when progress hits 100.
+- `loadgo:options` is guarded by an `isUpdate` flag computed before the `if/else` branch. It fires only on the update path (existing options + user-provided options), not during first-time init and not when `options()` is used as a getter.
+
 ## jQuery 4 compatibility notes
 
 - `$.inArray()` removed — use `Array.prototype.includes()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,11 @@ Both implementations dispatch native DOM `CustomEvent`s (not jQuery `.trigger()`
 **Implementation rules that are not obvious from the code:**
 
 - `dispatchCustomEvent` requires a raw DOM element. In jQuery plugin methods, `this` is a jQuery wrapper — always use `this[0]` (or `$this[0]` / `rawElement`). The `_setprogress` helper in `loadgo.js` normalises via `const rawElement = $element[0]` for this reason.
+- `CUSTOM_EVENTS` (the `type → 'loadgo:type'` lookup map) is defined at IIFE scope, above `dispatchCustomEvent`, so it is not recreated on every call.
 - `resetprogress` and `stop` call `_setprogress(..., false)` (`shouldEmit = false`) and then dispatch their own events (`loadgo:reset` / `loadgo:stop`). This prevents `loadgo:progress` from firing alongside them.
 - `loadgo:complete` is guarded by `!data.interval` — it never fires inside a loop even when progress hits 100.
 - `loadgo:options` is guarded by an `isUpdate` flag computed before the `if/else` branch. It fires only on the update path (existing options + user-provided options), not during first-time init and not when `options()` is used as a getter.
+- Events with no payload (`loadgo:init`, `loadgo:start`, `loadgo:cycle`, `loadgo:destroy`) are dispatched without a `detail` argument — the Web API defaults `event.detail` to `null`. The TypeScript types use `CustomEvent<null>` accordingly.
 
 ## jQuery 4 compatibility notes
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,10 @@ logo.addEventListener('loadgo:options', (e) => {
   // e.detail is typed as LoadgoOptions
   console.log(e.detail.bgcolor)
 })
+
+logo.addEventListener('loadgo:init', (e) => {
+  // e.detail is null — events with no payload have CustomEvent<null>
+})
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
   - [Custom animation timing](#custom-animation-timing)
   - [Accessibility](#accessibility)
   - [Methods](#methods)
+  - [Custom events](#custom-events)
 - [Real-world example](#real-world-example)
 - [Examples](#examples)
 - [Tests](#tests)
@@ -316,6 +317,73 @@ $('#logo').loadgo('destroy');
 
 // Pure JavaScript
 Loadgo.destroy(document.getElementById('logo'));
+```
+
+---
+
+### Custom events
+
+LoadGo dispatches native DOM [`CustomEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)s at key lifecycle points. All events bubble, so you can listen on a parent element if needed.
+
+Events work with both `addEventListener` and jQuery's `.on()`:
+
+```js
+// Pure JavaScript
+document.getElementById('logo').addEventListener('loadgo:complete', () => {
+  console.log('Loading complete!')
+})
+
+// jQuery
+$('#logo').on('loadgo:complete', () => {
+  console.log('Loading complete!')
+})
+```
+
+Access the event payload via `event.detail`:
+
+```js
+document.getElementById('logo').addEventListener('loadgo:progress', (e) => {
+  console.log(`Progress: ${e.detail.progress}%`)
+})
+
+document.getElementById('logo').addEventListener('loadgo:error', (e) => {
+  console.warn('LoadGo error:', e.detail.message)
+})
+```
+
+#### Event reference
+
+| Event | Fires when | `event.detail` |
+| --- | --- | --- |
+| `loadgo:init` | `init()` completes | — |
+| `loadgo:error` | invalid usage (non-`img` element, loop/stop on uninitialized, double loop) | `{ message: string }` |
+| `loadgo:options` | `options()` is called as a setter after init | merged `LoadgoOptions` object |
+| `loadgo:progress` | `setprogress()` is called | `{ progress: number }` |
+| `loadgo:complete` | progress reaches 100 **outside** of a loop | `{ progress: 100 }` |
+| `loadgo:reset` | `resetprogress()` is called | `{ progress: 0 }` |
+| `loadgo:start` | `loop()` starts | — |
+| `loadgo:cycle` | loop completes one full back-and-forth (bounces back to 0) | — |
+| `loadgo:stop` | `stop()` is called | `{ progress: 100 }` |
+| `loadgo:destroy` | `destroy()` completes | — |
+
+> **Note:** `loadgo:progress` is **not** fired by `resetprogress()` or `stop()` — those operations dispatch `loadgo:reset` and `loadgo:stop` respectively. Similarly, `loadgo:complete` is suppressed while a loop is running, even when progress internally reaches 100.
+
+#### TypeScript
+
+Event types are declared in `LoadgoEventMap` and are automatically applied to `HTMLImageElement.addEventListener`:
+
+```ts
+const logo = document.getElementById('logo') as HTMLImageElement
+
+logo.addEventListener('loadgo:progress', (e) => {
+  // e.detail is typed as { progress: number }
+  console.log(e.detail.progress)
+})
+
+logo.addEventListener('loadgo:options', (e) => {
+  // e.detail is typed as LoadgoOptions
+  console.log(e.detail.bgcolor)
+})
 ```
 
 ---

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,7 @@ export default [
     },
   },
   {
-    files: ['examples/javascript/main.js'],
+    files: ['examples/javascript/main.js', 'examples/javascript/events.js'],
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: 'script',
@@ -30,7 +30,7 @@ export default [
     },
   },
   {
-    files: ['examples/jquery/main.js'],
+    files: ['examples/jquery/main.js', 'examples/jquery/events.js'],
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: 'script',

--- a/examples/javascript/events.html
+++ b/examples/javascript/events.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <title>LoadGo - Custom Events (Vanilla JS)</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-white">
+
+    <div class="max-w-4xl mx-auto px-4 pt-5 pb-16">
+
+      <h2 class="text-2xl font-semibold border-b border-gray-200 pb-3 mb-2">LoadGo – Custom Events (Vanilla JS)</h2>
+      <p class="text-gray-600 mb-1">
+        Every LoadGo method dispatches a native DOM <code class="bg-gray-100 px-1 rounded">CustomEvent</code> that bubbles.
+        Use the controls below and watch the event log to see what fires.
+      </p>
+      <p class="mb-6">
+        <a href="index.html" class="text-blue-600 hover:underline text-sm">← Back to examples</a>
+      </p>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+
+        <!-- Left: image + controls -->
+        <div>
+          <div class="flex justify-center mb-4 min-h-[160px] items-center">
+            <img id="demo-image" src="../logos/disney.png" alt="Demo Logo" class="max-w-full h-auto mx-auto" />
+          </div>
+
+          <div id="progress-display" class="text-center text-3xl font-bold mb-5 text-gray-700">0%</div>
+
+          <div class="flex flex-wrap gap-2 justify-center">
+            <button id="btn-set50"    class="px-3 py-1.5 bg-blue-600   text-white text-sm rounded hover:bg-blue-700">Set 50%</button>
+            <button id="btn-set100"   class="px-3 py-1.5 bg-green-600  text-white text-sm rounded hover:bg-green-700">Set 100%</button>
+            <button id="btn-reset"    class="px-3 py-1.5 bg-orange-500 text-white text-sm rounded hover:bg-orange-600">Reset</button>
+            <button id="btn-loop"     class="px-3 py-1.5 bg-teal-600   text-white text-sm rounded hover:bg-teal-700">Loop</button>
+            <button id="btn-stop"     class="px-3 py-1.5 bg-yellow-500 text-white text-sm rounded hover:bg-yellow-600">Stop</button>
+            <button id="btn-options"  class="px-3 py-1.5 bg-purple-600 text-white text-sm rounded hover:bg-purple-700">Change options</button>
+            <button id="btn-destroy"  class="px-3 py-1.5 bg-red-600    text-white text-sm rounded hover:bg-red-700">Destroy / Re-init</button>
+          </div>
+
+          <div class="mt-5 flex items-center gap-2 justify-center">
+            <input type="checkbox" id="show-progress" checked class="rounded" />
+            <label for="show-progress" class="text-sm text-gray-600">
+              Show <code class="bg-gray-100 px-1 rounded">loadgo:progress</code> events
+            </label>
+          </div>
+        </div>
+
+        <!-- Right: event log -->
+        <div>
+          <div class="flex items-center justify-between mb-2">
+            <h3 class="font-semibold text-gray-800">Event log</h3>
+            <button id="btn-clear" class="text-xs text-gray-500 hover:text-gray-700 underline">Clear</button>
+          </div>
+          <div id="event-log" class="border border-gray-200 rounded bg-gray-50 h-96 overflow-y-auto p-2 font-mono text-xs space-y-1">
+            <div class="text-gray-400 italic">Events will appear here…</div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <script type="text/javascript" src="../../packages/core/loadgo-vanilla.js"></script>
+    <script type="text/javascript" src="events.js"></script>
+  </body>
+</html>

--- a/examples/javascript/events.js
+++ b/examples/javascript/events.js
@@ -1,0 +1,112 @@
+const BADGE = {
+  'loadgo:init': 'bg-blue-100 text-blue-800',
+  'loadgo:error': 'bg-red-100 text-red-800',
+  'loadgo:options': 'bg-purple-100 text-purple-800',
+  'loadgo:progress': 'bg-gray-100 text-gray-500',
+  'loadgo:complete': 'bg-green-100 text-green-800',
+  'loadgo:reset': 'bg-orange-100 text-orange-800',
+  'loadgo:start': 'bg-teal-100 text-teal-800',
+  'loadgo:cycle': 'bg-teal-50 text-teal-700',
+  'loadgo:stop': 'bg-yellow-100 text-yellow-800',
+  'loadgo:destroy': 'bg-red-100 text-red-900',
+}
+
+const ALL_EVENTS = Object.keys(BADGE)
+
+let startTime = Date.now()
+let looping = false
+
+function logEvent(e) {
+  if (e.type === 'loadgo:progress' && !document.getElementById('show-progress').checked) return
+
+  const log = document.getElementById('event-log')
+  const placeholder = log.querySelector('.italic')
+  if (placeholder) placeholder.remove()
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(2)
+  const detail = e.detail !== undefined ? JSON.stringify(e.detail) : ''
+
+  const entry = document.createElement('div')
+  entry.className = 'flex items-baseline gap-2'
+  entry.innerHTML =
+    `<span class="text-gray-400 shrink-0 w-14 text-right">+${elapsed}s</span>` +
+    `<span class="px-1.5 py-0.5 rounded font-medium shrink-0 ${BADGE[e.type]}">${e.type}</span>` +
+    (detail ? `<span class="text-gray-500 truncate">${detail}</span>` : '')
+
+  log.appendChild(entry)
+  log.scrollTop = log.scrollHeight
+}
+
+window.onload = () => {
+  const image = document.getElementById('demo-image')
+  const progressDisplay = document.getElementById('progress-display')
+
+  // Attach all event listeners once — they survive destroy/re-init cycles
+  // because they're on the <img> element, not on the overlay or container.
+  ALL_EVENTS.forEach((type) => image.addEventListener(type, logEvent))
+
+  image.addEventListener('loadgo:progress', (e) => {
+    progressDisplay.textContent = `${e.detail.progress}%`
+  })
+  image.addEventListener('loadgo:reset', () => {
+    progressDisplay.textContent = '0%'
+  })
+  image.addEventListener('loadgo:stop', () => {
+    progressDisplay.textContent = '100%'
+  })
+  image.addEventListener('loadgo:destroy', () => {
+    progressDisplay.textContent = '0%'
+  })
+
+  function init() {
+    Loadgo.init(image)
+    startTime = Date.now()
+    looping = false
+  }
+
+  image.onload = () => init()
+  if (image.complete) init()
+
+  document.getElementById('btn-set50').addEventListener('click', () => {
+    Loadgo.setprogress(image, 50)
+  })
+
+  document.getElementById('btn-set100').addEventListener('click', () => {
+    Loadgo.setprogress(image, 100)
+  })
+
+  document.getElementById('btn-reset').addEventListener('click', () => {
+    Loadgo.resetprogress(image)
+  })
+
+  document.getElementById('btn-loop').addEventListener('click', () => {
+    if (looping) return
+    looping = true
+    Loadgo.loop(image, 30)
+  })
+
+  document.getElementById('btn-stop').addEventListener('click', () => {
+    looping = false
+    Loadgo.stop(image)
+  })
+
+  const bgColors = ['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD']
+  let colorIndex = 0
+  document.getElementById('btn-options').addEventListener('click', () => {
+    Loadgo.options(image, { bgcolor: bgColors[colorIndex % bgColors.length] })
+    colorIndex++
+  })
+
+  document.getElementById('btn-destroy').addEventListener('click', () => {
+    looping = false
+    Loadgo.destroy(image)
+    // Re-init after a tick so loadgo:destroy lands in the log first
+    setTimeout(() => init(), 50)
+  })
+
+  document.getElementById('btn-clear').addEventListener('click', () => {
+    document.getElementById('event-log').innerHTML =
+      '<div class="text-gray-400 italic">Events will appear here…</div>'
+    startTime = Date.now()
+  })
+}

--- a/examples/javascript/index.html
+++ b/examples/javascript/index.html
@@ -18,6 +18,7 @@
       <h2 class="text-2xl font-semibold border-b border-gray-200 pb-3 mb-2">LoadGo - Javascript Examples</h2>
       <ul class="mt-4 mb-8">
         <li><a href="https://github.com/franverona/loadgo" class="text-blue-600 hover:underline">GitHub</a></li>
+        <li><a href="events.html" class="text-blue-600 hover:underline">Custom events demo →</a></li>
       </ul>
 
       <div id="examples">

--- a/examples/jquery/events.html
+++ b/examples/jquery/events.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <title>LoadGo - Custom Events (jQuery)</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-white">
+
+    <div class="max-w-4xl mx-auto px-4 pt-5 pb-16">
+
+      <h2 class="text-2xl font-semibold border-b border-gray-200 pb-3 mb-2">LoadGo – Custom Events (jQuery)</h2>
+      <p class="text-gray-600 mb-1">
+        Every LoadGo method dispatches a native DOM <code class="bg-gray-100 px-1 rounded">CustomEvent</code> that bubbles.
+        Use the controls below and watch the event log to see what fires.
+      </p>
+      <p class="mb-6">
+        <a href="index.html" class="text-blue-600 hover:underline text-sm">← Back to examples</a>
+      </p>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+
+        <!-- Left: image + controls -->
+        <div>
+          <div class="flex justify-center mb-4 min-h-[160px] items-center">
+            <img id="demo-image" src="../logos/disney.png" alt="Demo Logo" class="max-w-full h-auto mx-auto" />
+          </div>
+
+          <div id="progress-display" class="text-center text-3xl font-bold mb-5 text-gray-700">0%</div>
+
+          <div class="flex flex-wrap gap-2 justify-center">
+            <button id="btn-set50"    class="px-3 py-1.5 bg-blue-600   text-white text-sm rounded hover:bg-blue-700">Set 50%</button>
+            <button id="btn-set100"   class="px-3 py-1.5 bg-green-600  text-white text-sm rounded hover:bg-green-700">Set 100%</button>
+            <button id="btn-reset"    class="px-3 py-1.5 bg-orange-500 text-white text-sm rounded hover:bg-orange-600">Reset</button>
+            <button id="btn-loop"     class="px-3 py-1.5 bg-teal-600   text-white text-sm rounded hover:bg-teal-700">Loop</button>
+            <button id="btn-stop"     class="px-3 py-1.5 bg-yellow-500 text-white text-sm rounded hover:bg-yellow-600">Stop</button>
+            <button id="btn-options"  class="px-3 py-1.5 bg-purple-600 text-white text-sm rounded hover:bg-purple-700">Change options</button>
+            <button id="btn-destroy"  class="px-3 py-1.5 bg-red-600    text-white text-sm rounded hover:bg-red-700">Destroy / Re-init</button>
+          </div>
+
+          <div class="mt-5 flex items-center gap-2 justify-center">
+            <input type="checkbox" id="show-progress" checked class="rounded" />
+            <label for="show-progress" class="text-sm text-gray-600">
+              Show <code class="bg-gray-100 px-1 rounded">loadgo:progress</code> events
+            </label>
+          </div>
+        </div>
+
+        <!-- Right: event log -->
+        <div>
+          <div class="flex items-center justify-between mb-2">
+            <h3 class="font-semibold text-gray-800">Event log</h3>
+            <button id="btn-clear" class="text-xs text-gray-500 hover:text-gray-700 underline">Clear</button>
+          </div>
+          <div id="event-log" class="border border-gray-200 rounded bg-gray-50 h-96 overflow-y-auto p-2 font-mono text-xs space-y-1">
+            <div class="text-gray-400 italic">Events will appear here…</div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <script src="https://code.jquery.com/jquery-4.0.0.min.js"></script>
+    <script type="text/javascript" src="../../packages/core/loadgo.js"></script>
+    <script type="text/javascript" src="events.js"></script>
+  </body>
+</html>

--- a/examples/jquery/events.js
+++ b/examples/jquery/events.js
@@ -1,0 +1,112 @@
+const BADGE = {
+  'loadgo:init': 'bg-blue-100 text-blue-800',
+  'loadgo:error': 'bg-red-100 text-red-800',
+  'loadgo:options': 'bg-purple-100 text-purple-800',
+  'loadgo:progress': 'bg-gray-100 text-gray-500',
+  'loadgo:complete': 'bg-green-100 text-green-800',
+  'loadgo:reset': 'bg-orange-100 text-orange-800',
+  'loadgo:start': 'bg-teal-100 text-teal-800',
+  'loadgo:cycle': 'bg-teal-50 text-teal-700',
+  'loadgo:stop': 'bg-yellow-100 text-yellow-800',
+  'loadgo:destroy': 'bg-red-100 text-red-900',
+}
+
+const ALL_EVENTS = Object.keys(BADGE)
+
+let startTime = Date.now()
+let looping = false
+
+function logEvent(e) {
+  if (e.type === 'loadgo:progress' && !document.getElementById('show-progress').checked) return
+
+  const $log = $('#event-log')
+  $log.find('.italic').remove()
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(2)
+  // jQuery wraps the native CustomEvent — access detail via originalEvent
+  const detail = e.originalEvent?.detail !== undefined ? JSON.stringify(e.originalEvent.detail) : ''
+
+  const entry = document.createElement('div')
+  entry.className = 'flex items-baseline gap-2'
+  entry.innerHTML =
+    `<span class="text-gray-400 shrink-0 w-14 text-right">+${elapsed}s</span>` +
+    `<span class="px-1.5 py-0.5 rounded font-medium shrink-0 ${BADGE[e.type]}">${e.type}</span>` +
+    (detail ? `<span class="text-gray-500 truncate">${detail}</span>` : '')
+
+  $log.append(entry)
+  $log.scrollTop($log[0].scrollHeight)
+}
+
+$(document).ready(() => {
+  const $image = $('#demo-image')
+  const $progressDisplay = $('#progress-display')
+
+  // jQuery's .on() receives native CustomEvents because it uses addEventListener internally.
+  // Access event.detail via event.originalEvent.detail (jQuery wraps the native event).
+  ALL_EVENTS.forEach((type) => $image.on(type, logEvent))
+
+  $image.on('loadgo:progress', (e) => {
+    $progressDisplay.text(`${e.originalEvent.detail.progress}%`)
+  })
+  $image.on('loadgo:reset', () => {
+    $progressDisplay.text('0%')
+  })
+  $image.on('loadgo:stop', () => {
+    $progressDisplay.text('100%')
+  })
+  $image.on('loadgo:destroy', () => {
+    $progressDisplay.text('0%')
+  })
+
+  function init() {
+    $image.loadgo()
+    startTime = Date.now()
+    looping = false
+  }
+
+  $image
+    .on('load', () => init())
+    .each((_, el) => {
+      if (el.complete) init()
+    })
+
+  $('#btn-set50').on('click', () => {
+    $image.loadgo('setprogress', 50)
+  })
+  $('#btn-set100').on('click', () => {
+    $image.loadgo('setprogress', 100)
+  })
+  $('#btn-reset').on('click', () => {
+    $image.loadgo('resetprogress')
+  })
+
+  $('#btn-loop').on('click', () => {
+    if (looping) return
+    looping = true
+    $image.loadgo('loop', 30)
+  })
+
+  $('#btn-stop').on('click', () => {
+    looping = false
+    $image.loadgo('stop')
+  })
+
+  const bgColors = ['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD']
+  let colorIndex = 0
+  $('#btn-options').on('click', () => {
+    $image.loadgo('options', { bgcolor: bgColors[colorIndex % bgColors.length] })
+    colorIndex++
+  })
+
+  $('#btn-destroy').on('click', () => {
+    looping = false
+    $image.loadgo('destroy')
+    // Re-init after a tick so loadgo:destroy lands in the log first
+    setTimeout(() => init(), 50)
+  })
+
+  $('#btn-clear').on('click', () => {
+    $('#event-log').html('<div class="text-gray-400 italic">Events will appear here…</div>')
+    startTime = Date.now()
+  })
+})

--- a/examples/jquery/index.html
+++ b/examples/jquery/index.html
@@ -18,6 +18,7 @@
       <h2 class="text-2xl font-semibold border-b border-gray-200 pb-3 mb-2">LoadGo - jQuery Examples</h2>
       <ul class="mt-4 mb-8">
         <li><a href="https://github.com/franverona/loadgo" class="text-blue-600 hover:underline">GitHub</a></li>
+        <li><a href="events.html" class="text-blue-600 hover:underline">Custom events demo →</a></li>
       </ul>
 
       <div id="examples">

--- a/packages/core/loadgo-vanilla.js
+++ b/packages/core/loadgo-vanilla.js
@@ -616,7 +616,7 @@
 
     if (getIndex(element.id) === -1) {
       const message =
-        'Trying to loop a non initialized element. You have to run "init" method first.'
+        'Trying to stop loop a non initialized element. You have to run "init" method first.'
       dispatchCustomEvent(element, 'error', { message })
       console.error(message)
       return

--- a/packages/core/loadgo-vanilla.js
+++ b/packages/core/loadgo-vanilla.js
@@ -28,11 +28,19 @@
     }
 
     if (!(element instanceof HTMLElement)) {
-      throw new Error('LoadGo only works on one element at a time. Try with a valid #id.')
+      const message = 'LoadGo only works on one element at a time. Try with a valid #id.'
+      if (element instanceof EventTarget) {
+        dispatchCustomEvent(element, 'error', { message })
+      }
+      throw new Error(message)
     }
 
     if (element.nodeName !== 'IMG') {
-      throw new Error('LoadGo only works on img elements.')
+      const message = 'LoadGo only works on img elements.'
+      if (element instanceof EventTarget) {
+        dispatchCustomEvent(element, 'error', { message })
+      }
+      throw new Error(message)
     }
 
     return true
@@ -42,6 +50,108 @@
   const parseOffset = (element, property) => {
     const measure = getComputedStyle(element)[property]
     return parseFloat(measure) || 0
+  }
+
+  const dispatchCustomEvent = (element, type, detail) => {
+    const CUSTOM_EVENTS = {
+      complete: 'loadgo:complete',
+      cycle: 'loadgo:cycle',
+      destroy: 'loadgo:destroy',
+      error: 'loadgo:error',
+      init: 'loadgo:init',
+      options: 'loadgo:options',
+      progress: 'loadgo:progress',
+      reset: 'loadgo:reset',
+      start: 'loadgo:start',
+      stop: 'loadgo:stop',
+    }
+    const eventType = CUSTOM_EVENTS[type] ?? null
+    if (!eventType) {
+      throw new Error(`Unable to dispatch unknown event type: ${type}`)
+    }
+
+    element.dispatchEvent(new CustomEvent(eventType, { detail, bubbles: true }))
+  }
+
+  const _setprogress = function (element, progress, shouldEmit = true) {
+    if (!elementIsValid(element)) {
+      return
+    }
+
+    // LoadGo expects progress number between 0 (0%) and 100 (100%).
+    if (progress < 0 || progress > 100) {
+      return
+    }
+
+    // Element exists?
+    const domElementsIndex = getIndex(element.id)
+    if (domElementsIndex === -1) {
+      return
+    }
+
+    const data = getProperties(element.id)
+
+    if (data !== null) {
+      const overlay = document.getElementById(data.overlay)
+      const w = data.width
+      const h = data.height
+
+      if (overlay) {
+        const direction = data.direction
+        if (direction === 'lr') {
+          // Left to right animation
+          overlay.style.width = `${w * (1 - progress / 100)}px`
+        } else if (direction === 'rl') {
+          // Right to left animation
+          overlay.style.width = `${w * (1 - progress / 100)}px`
+        } else if (direction === 'bt') {
+          // Bottom to top animation
+          overlay.style.height = `${h * (1 - progress / 100)}px`
+        } else if (direction === 'tb') {
+          // Top to bottom animation
+          const _h = h * (1 - progress / 100)
+          overlay.style.height = `${_h}px`
+          overlay.style.top = `${h - _h}px`
+        }
+        overlay.setAttribute('aria-valuenow', progress)
+      } else {
+        element.setAttribute('aria-valuenow', progress)
+        const filter = data.filter
+        let p
+        switch (filter) {
+          case 'blur':
+            p = (100 - progress) / 10 // maps 0–100% progress to 10px–0px blur radius
+            element.style.filter = `${filter}(${p}px)`
+            break
+          case 'hue-rotate':
+            p = (progress * 360) / 100
+            element.style.filter = `${filter}(${p}deg)`
+            break
+          case 'opacity':
+            p = progress / 100
+            element.style.filter = `${filter}(${p})`
+            break
+          default:
+            p = 1 - progress / 100
+            element.style.filter = `${filter}(${p})`
+        }
+      }
+    }
+
+    domElements[domElementsIndex].properties.progress = progress
+
+    const onProgress = getProperties(element.id)?.onProgress
+    if (typeof onProgress === 'function') {
+      onProgress(progress)
+    }
+
+    if (shouldEmit) {
+      dispatchCustomEvent(element, 'progress', { progress })
+      // Only fire complete if it hits 100 AND we aren't currently looping
+      if (progress === 100 && (!data || !data.interval)) {
+        dispatchCustomEvent(element, 'complete', { progress: 100 })
+      }
+    }
   }
 
   let _idCounter = 0
@@ -69,11 +179,13 @@
   const Loadgo = window.Loadgo || {}
 
   /**
-   * Init Loadgo in an specific element
-   * @param  {DOM} element  DOM element using document.getElementById
-   * @param  {JSON} useroptions Loadgo options
+   * Initialise LoadGo on an `<img>` element.
+   * @param  {HTMLImageElement} element  DOM element using document.getElementById
+   * @param  {object} [userOptions]  Loadgo options
+   * @fires loadgo:init
+   * @fires loadgo:error
    */
-  Loadgo.init = function (element, useroptions) {
+  Loadgo.init = function (element, userOptions) {
     if (!elementIsValid(element)) {
       return
     }
@@ -94,7 +206,7 @@
     })
     const domElementsIndex = domElements.length - 1
 
-    const pluginOptions = Loadgo.options(element, useroptions)
+    const pluginOptions = Loadgo.options(element, userOptions)
 
     const overlay = document.createElement('div')
     overlay.id = uniqueId() // We need to set a unique id so we can retrieve it later when needed
@@ -324,9 +436,17 @@
 
     window.addEventListener('resize', resizeFunction)
     domElements[domElementsIndex].properties.resizeFunction = resizeFunction
+
+    dispatchCustomEvent(element, 'init')
   }
 
-  Loadgo.options = function (element, useroptions) {
+  /**
+   * Get or set options for an already-initialised element.
+   * @param  {DOM} element  DOM element using document.getElementById
+   * @param  {object} [userOptions]  Loadgo options to update. Omit to use as getter.
+   * @fires loadgo:options - Only fired when called as a setter after init.
+   */
+  Loadgo.options = function (element, userOptions) {
     if (!elementIsValid(element)) {
       return
     }
@@ -340,19 +460,21 @@
     let currentOptions = domElements[domElementsIndex].properties
 
     // Parse to number the 'opacity' option if provided
-    if (typeof useroptions !== 'undefined' && typeof useroptions.opacity !== 'undefined') {
-      useroptions.opacity = parseFloat(useroptions.opacity)
+    if (typeof userOptions !== 'undefined' && typeof userOptions.opacity !== 'undefined') {
+      userOptions.opacity = parseFloat(userOptions.opacity)
     }
+
+    const isUpdate = Object.keys(currentOptions).length > 0 && typeof userOptions !== 'undefined'
 
     if (Object.keys(currentOptions).length === 0) {
       // First-time init: apply defaults then overlay user options
-      currentOptions = extend(defaultOptions, useroptions)
-    } else if (typeof useroptions === 'undefined') {
+      currentOptions = extend(defaultOptions, userOptions)
+    } else if (typeof userOptions === 'undefined') {
       // Getter: no options provided, return current options as-is
       return currentOptions
     } else {
       // Update: merge new options into existing
-      currentOptions = extend(currentOptions, useroptions)
+      currentOptions = extend(currentOptions, userOptions)
     }
 
     // Check for valid direction
@@ -374,90 +496,27 @@
     // Store user options with default options
     domElements[domElementsIndex].properties = currentOptions
 
+    if (isUpdate) {
+      dispatchCustomEvent(element, 'options', currentOptions)
+    }
+
     return currentOptions
   }
 
   /**
-   * Set progress to specific value
-   * @param  {DOM} element  DOM element using document.getElementById
-   * @param  {Number} progress Progress value (between 0 and 100)
+   * Set progress (0–100).
+   * @param  {HTMLImageElement} element  DOM element using document.getElementById
+   * @param  {number} progress  Progress value (between 0 and 100)
+   * @fires loadgo:progress
+   * @fires loadgo:complete - Only fired when progress reaches 100% outside of a loop.
    */
   Loadgo.setprogress = function (element, progress) {
-    if (!elementIsValid(element)) {
-      return
-    }
-
-    // LoadGo expects progress number between 0 (0%) and 100 (100%).
-    if (progress < 0 || progress > 100) {
-      return
-    }
-
-    // Element exists?
-    const domElementsIndex = getIndex(element.id)
-    if (domElementsIndex === -1) {
-      return
-    }
-
-    const data = getProperties(element.id)
-
-    if (data !== null) {
-      const overlay = document.getElementById(data.overlay)
-      const w = data.width
-      const h = data.height
-
-      if (overlay) {
-        const direction = data.direction
-        if (direction === 'lr') {
-          // Left to right animation
-          overlay.style.width = `${w * (1 - progress / 100)}px`
-        } else if (direction === 'rl') {
-          // Right to left animation
-          overlay.style.width = `${w * (1 - progress / 100)}px`
-        } else if (direction === 'bt') {
-          // Bottom to top animation
-          overlay.style.height = `${h * (1 - progress / 100)}px`
-        } else if (direction === 'tb') {
-          // Top to bottom animation
-          const _h = h * (1 - progress / 100)
-          overlay.style.height = `${_h}px`
-          overlay.style.top = `${h - _h}px`
-        }
-        overlay.setAttribute('aria-valuenow', progress)
-      } else {
-        element.setAttribute('aria-valuenow', progress)
-        const filter = data.filter
-        let p
-        switch (filter) {
-          case 'blur':
-            p = (100 - progress) / 10 // maps 0–100% progress to 10px–0px blur radius
-            element.style.filter = `${filter}(${p}px)`
-            break
-          case 'hue-rotate':
-            p = (progress * 360) / 100
-            element.style.filter = `${filter}(${p}deg)`
-            break
-          case 'opacity':
-            p = progress / 100
-            element.style.filter = `${filter}(${p})`
-            break
-          default:
-            p = 1 - progress / 100
-            element.style.filter = `${filter}(${p})`
-        }
-      }
-    }
-
-    domElements[domElementsIndex].properties.progress = progress
-
-    const onProgress = getProperties(element.id)?.onProgress
-    if (typeof onProgress === 'function') {
-      onProgress(progress)
-    }
+    _setprogress(element, progress, true)
   }
 
   /**
-   * Return current progress
-   * @param  {DOM} element  DOM element using document.getElementById
+   * Return the current progress value.
+   * @param  {HTMLImageElement} element  DOM element using document.getElementById
    */
   Loadgo.getprogress = (element) => {
     if (!elementIsValid(element)) {
@@ -469,17 +528,22 @@
   }
 
   /**
-   * Reset progress
-   * @param  {DOM} element  DOM element using document.getElementById
+   * Reset progress back to 0.
+   * @param  {HTMLImageElement} element  DOM element using document.getElementById
+   * @fires loadgo:reset
    */
   Loadgo.resetprogress = (element) => {
-    Loadgo.setprogress(element, 0)
+    _setprogress(element, 0, false)
+    dispatchCustomEvent(element, 'reset', { progress: 0 })
   }
 
   /**
-   * Overlay loops back and forth
-   * @param  {DOM} element  DOM element using document.getElementById
-   * @param  {number} duration Interval duration in ms
+   * Start an indefinite back-and-forth animation loop.
+   * @param  {HTMLImageElement} element  DOM element using document.getElementById
+   * @param  {number} duration  Interval duration in ms
+   * @fires loadgo:start
+   * @fires loadgo:cycle - Fired each time the loop completes one full back-and-forth.
+   * @fires loadgo:error
    */
   Loadgo.loop = function (element, duration) {
     if (!elementIsValid(element)) {
@@ -487,22 +551,29 @@
     }
 
     if (getIndex(element.id) === -1) {
-      console.error(
-        'Trying to loop a non initialized element. You have to run "init" method first.',
-      )
+      const message =
+        'Trying to loop a non initialized element. You have to run "init" method first.'
+      dispatchCustomEvent(element, 'error', { message })
+      console.error(message)
       return
     }
 
     const data = getProperties(element.id)
     if (data === null) {
-      console.error('Element do not have Loadgo properties.')
+      const message = 'Element do not have Loadgo properties.'
+      dispatchCustomEvent(element, 'error', { message })
+      console.error(message)
       return
     }
 
     if (data.interval) {
-      console.error('LoadGo requires you to stop the current loop before modifying it.')
+      const message = 'LoadGo requires you to stop the current loop before modifying it.'
+      dispatchCustomEvent(element, 'error', { message })
+      console.error(message)
       return
     }
+
+    dispatchCustomEvent(element, 'start')
 
     // Store interval so we can stop it later
     let toggle = true
@@ -517,6 +588,7 @@
         domElements[domIndex].properties.progress -= 1
         if (domElements[domIndex].properties.progress <= 0) {
           toggle = true
+          dispatchCustomEvent(element, 'cycle')
         }
       }
       // Remove transition animation
@@ -526,13 +598,16 @@
         loopOverlay.style.transition = 'none'
       }
 
-      Loadgo.setprogress(element, domElements[domIndex].properties.progress)
+      const progress = domElements[domIndex].properties.progress
+      _setprogress(element, progress, true)
     }, duration)
   }
 
   /**
-   * Stops the loop interval and shows image
-   * @param {DOM} element
+   * Stop the loop and reveal the full image.
+   * @param  {HTMLImageElement} element  DOM element using document.getElementById
+   * @fires loadgo:stop
+   * @fires loadgo:error
    */
   Loadgo.stop = function (element) {
     if (!elementIsValid(element)) {
@@ -540,21 +615,24 @@
     }
 
     if (getIndex(element.id) === -1) {
-      console.error(
-        'Trying to stop loop for a non initialized element. You have to run "init" method first.',
-      )
+      const message =
+        'Trying to loop a non initialized element. You have to run "init" method first.'
+      dispatchCustomEvent(element, 'error', { message })
+      console.error(message)
       return
     }
 
     const idx = getIndex(element.id)
     clearInterval(domElements[idx].properties.interval)
     domElements[idx].properties.interval = null
-    Loadgo.setprogress(element, 100)
+    _setprogress(element, 100, false)
+    dispatchCustomEvent(element, 'stop', { progress: 100 })
   }
 
   /**
-   * Remove all plugin properties
-   * @param  {DOM} element  DOM element using document.getElementById
+   * Remove the overlay and restore the original DOM structure.
+   * @param  {HTMLImageElement} element  DOM element using document.getElementById
+   * @fires loadgo:destroy
    */
   Loadgo.destroy = function (element) {
     const domElementsIndex = getIndex(element.id)
@@ -588,6 +666,8 @@
       element.removeAttribute('aria-valuenow')
       element.removeAttribute('aria-label')
     }
+
+    dispatchCustomEvent(element, 'destroy')
   }
 
   window.Loadgo = Loadgo

--- a/packages/core/loadgo-vanilla.js
+++ b/packages/core/loadgo-vanilla.js
@@ -52,19 +52,20 @@
     return parseFloat(measure) || 0
   }
 
+  const CUSTOM_EVENTS = {
+    complete: 'loadgo:complete',
+    cycle: 'loadgo:cycle',
+    destroy: 'loadgo:destroy',
+    error: 'loadgo:error',
+    init: 'loadgo:init',
+    options: 'loadgo:options',
+    progress: 'loadgo:progress',
+    reset: 'loadgo:reset',
+    start: 'loadgo:start',
+    stop: 'loadgo:stop',
+  }
+
   const dispatchCustomEvent = (element, type, detail) => {
-    const CUSTOM_EVENTS = {
-      complete: 'loadgo:complete',
-      cycle: 'loadgo:cycle',
-      destroy: 'loadgo:destroy',
-      error: 'loadgo:error',
-      init: 'loadgo:init',
-      options: 'loadgo:options',
-      progress: 'loadgo:progress',
-      reset: 'loadgo:reset',
-      start: 'loadgo:start',
-      stop: 'loadgo:stop',
-    }
     const eventType = CUSTOM_EVENTS[type] ?? null
     if (!eventType) {
       throw new Error(`Unable to dispatch unknown event type: ${type}`)
@@ -616,7 +617,7 @@
 
     if (getIndex(element.id) === -1) {
       const message =
-        'Trying to stop loop a non initialized element. You have to run "init" method first.'
+        'Trying to stop loop for a non initialized element. You have to run "init" method first.'
       dispatchCustomEvent(element, 'error', { message })
       console.error(message)
       return

--- a/packages/core/loadgo-vanilla.js
+++ b/packages/core/loadgo-vanilla.js
@@ -87,6 +87,10 @@
     // Element exists?
     const domElementsIndex = getIndex(element.id)
     if (domElementsIndex === -1) {
+      dispatchCustomEvent(element, 'error', {
+        message:
+          'Trying to set progress on a non initialized element. You have to run "init" method first.',
+      })
       return
     }
 
@@ -498,7 +502,7 @@
     domElements[domElementsIndex].properties = currentOptions
 
     if (isUpdate) {
-      dispatchCustomEvent(element, 'options', currentOptions)
+      dispatchCustomEvent(element, 'options', { ...currentOptions })
     }
 
     return currentOptions

--- a/packages/core/loadgo-vanilla.js
+++ b/packages/core/loadgo-vanilla.js
@@ -536,8 +536,16 @@
    * Reset progress back to 0.
    * @param  {HTMLImageElement} element  DOM element using document.getElementById
    * @fires loadgo:reset
+   * @fires loadgo:error
    */
   Loadgo.resetprogress = (element) => {
+    if (getIndex(element.id) === -1) {
+      dispatchCustomEvent(element, 'error', {
+        message:
+          'Trying to reset progress on a non initialized element. You have to run "init" method first.',
+      })
+      return
+    }
     _setprogress(element, 0, false)
     dispatchCustomEvent(element, 'reset', { progress: 0 })
   }

--- a/packages/core/loadgo.js
+++ b/packages/core/loadgo.js
@@ -9,19 +9,20 @@ if (typeof jQuery === 'undefined')
     'LoadGo requires jQuery. Make sure you are loading jQuery before LoadGo, or try pure Javascript version instead.',
   )
 ;(function ($) {
+  const CUSTOM_EVENTS = {
+    complete: 'loadgo:complete',
+    cycle: 'loadgo:cycle',
+    destroy: 'loadgo:destroy',
+    error: 'loadgo:error',
+    init: 'loadgo:init',
+    options: 'loadgo:options',
+    progress: 'loadgo:progress',
+    reset: 'loadgo:reset',
+    start: 'loadgo:start',
+    stop: 'loadgo:stop',
+  }
+
   const dispatchCustomEvent = (element, type, detail) => {
-    const CUSTOM_EVENTS = {
-      complete: 'loadgo:complete',
-      cycle: 'loadgo:cycle',
-      destroy: 'loadgo:destroy',
-      error: 'loadgo:error',
-      init: 'loadgo:init',
-      options: 'loadgo:options',
-      progress: 'loadgo:progress',
-      reset: 'loadgo:reset',
-      start: 'loadgo:start',
-      stop: 'loadgo:stop',
-    }
     const eventType = CUSTOM_EVENTS[type] ?? null
     if (!eventType) {
       throw new Error(`Unable to dispatch unknown event type: ${type}`)
@@ -64,24 +65,24 @@ if (typeof jQuery === 'undefined')
       storedData.overlay = $overlay
     } else {
       rawElement.setAttribute('aria-valuenow', progress)
-      const $filter = pluginOptions.filter
+      const filter = pluginOptions.filter
       let p
-      switch ($filter) {
+      switch (filter) {
         case 'blur':
           p = (100 - progress) / 10
-          $element.css({ filter: `${$filter}(${p}px)` })
+          $element.css({ filter: `${filter}(${p}px)` })
           break
         case 'hue-rotate':
           p = (progress * 360) / 100
-          $element.css({ filter: `${$filter}(${p}deg)` })
+          $element.css({ filter: `${filter}(${p}deg)` })
           break
         case 'opacity':
           p = progress / 100
-          $element.css({ filter: `${$filter}(${p})` })
+          $element.css({ filter: `${filter}(${p})` })
           break
         default:
           p = 1 - progress / 100
-          $element.css({ filter: `${$filter}(${p})` })
+          $element.css({ filter: `${filter}(${p})` })
       }
     }
 

--- a/packages/core/loadgo.js
+++ b/packages/core/loadgo.js
@@ -36,7 +36,13 @@ if (typeof jQuery === 'undefined')
     const $element = $(element)
     const rawElement = $element[0]
     const data = $element.data('loadgo')
-    if (typeof data === 'undefined') return
+    if (typeof data === 'undefined') {
+      dispatchCustomEvent(rawElement, 'error', {
+        message:
+          'Trying to set progress on a non initialized element. You have to run "init" method first.',
+      })
+      return
+    }
 
     const storedData = { progress }
     const pluginOptions = $element.loadgo('options')
@@ -415,7 +421,7 @@ if (typeof jQuery === 'undefined')
       $this.data('loadgo-options', currentOptions)
 
       if (isUpdate) {
-        dispatchCustomEvent($this[0], 'options', currentOptions)
+        dispatchCustomEvent($this[0], 'options', { ...currentOptions })
       }
 
       return currentOptions

--- a/packages/core/loadgo.js
+++ b/packages/core/loadgo.js
@@ -452,8 +452,17 @@ if (typeof jQuery === 'undefined')
     /**
      * Reset progress
      * @fires loadgo:reset
+     * @fires loadgo:error
      */
     resetprogress: function () {
+      const data = $(this).data('loadgo')
+      if (typeof data === 'undefined') {
+        dispatchCustomEvent(this[0], 'error', {
+          message:
+            'Trying to reset progress on a non initialized element. You have to run "init" method first.',
+        })
+        return
+      }
       _setprogress(this, 0, false)
       dispatchCustomEvent(this[0], 'reset', { progress: 0 })
     },

--- a/packages/core/loadgo.js
+++ b/packages/core/loadgo.js
@@ -9,7 +9,104 @@ if (typeof jQuery === 'undefined')
     'LoadGo requires jQuery. Make sure you are loading jQuery before LoadGo, or try pure Javascript version instead.',
   )
 ;(function ($) {
+  const dispatchCustomEvent = (element, type, detail) => {
+    const CUSTOM_EVENTS = {
+      complete: 'loadgo:complete',
+      cycle: 'loadgo:cycle',
+      destroy: 'loadgo:destroy',
+      error: 'loadgo:error',
+      init: 'loadgo:init',
+      options: 'loadgo:options',
+      progress: 'loadgo:progress',
+      reset: 'loadgo:reset',
+      start: 'loadgo:start',
+      stop: 'loadgo:stop',
+    }
+    const eventType = CUSTOM_EVENTS[type] ?? null
+    if (!eventType) {
+      throw new Error(`Unable to dispatch unknown event type: ${type}`)
+    }
+    element.dispatchEvent(new CustomEvent(eventType, { detail, bubbles: true }))
+  }
+
+  const _setprogress = (element, progress, shouldEmit) => {
+    if (progress < 0 || progress > 100) return
+
+    const $element = $(element)
+    const rawElement = $element[0]
+    const data = $element.data('loadgo')
+    if (typeof data === 'undefined') return
+
+    const storedData = { progress }
+    const pluginOptions = $element.loadgo('options')
+    const $overlay = data.overlay
+    const $width = data.width
+    const $height = data.height
+    const direction = pluginOptions.direction
+
+    if ($overlay) {
+      let overlayWidth, overlayHeight
+      if (direction === 'lr') {
+        overlayWidth = $width * (1 - progress / 100)
+        $overlay[0].style.width = `${overlayWidth}px`
+      } else if (direction === 'rl') {
+        overlayWidth = $width * (1 - progress / 100)
+        $overlay[0].style.width = `${overlayWidth}px`
+      } else if (direction === 'bt') {
+        overlayHeight = $height * (1 - progress / 100)
+        $overlay[0].style.height = `${overlayHeight}px`
+      } else if (direction === 'tb') {
+        overlayHeight = $height * (1 - progress / 100)
+        $overlay[0].style.height = `${overlayHeight}px`
+        $overlay[0].style.top = `${$height - overlayHeight}px`
+      }
+      $overlay[0].setAttribute('aria-valuenow', progress)
+      storedData.overlay = $overlay
+    } else {
+      rawElement.setAttribute('aria-valuenow', progress)
+      const $filter = pluginOptions.filter
+      let p
+      switch ($filter) {
+        case 'blur':
+          p = (100 - progress) / 10
+          $element.css({ filter: `${$filter}(${p}px)` })
+          break
+        case 'hue-rotate':
+          p = (progress * 360) / 100
+          $element.css({ filter: `${$filter}(${p}deg)` })
+          break
+        case 'opacity':
+          p = progress / 100
+          $element.css({ filter: `${$filter}(${p})` })
+          break
+        default:
+          p = 1 - progress / 100
+          $element.css({ filter: `${$filter}(${p})` })
+      }
+    }
+
+    $element.data('loadgo', $.extend({}, data, storedData))
+
+    const onProgress = $element.loadgo('options').onProgress
+    if (typeof onProgress === 'function') {
+      onProgress(progress)
+    }
+
+    if (shouldEmit) {
+      dispatchCustomEvent(rawElement, 'progress', { progress })
+      if (progress === 100 && !data.interval) {
+        dispatchCustomEvent(rawElement, 'complete', { progress: 100 })
+      }
+    }
+  }
+
   const methods = {
+    /**
+     * Initialise LoadGo on the selected `<img>` element.
+     * @param  {object} [userOptions]  Loadgo options
+     * @fires loadgo:init
+     * @fires loadgo:error
+     */
     init: function (userOptions) {
       const $this = $(this)
 
@@ -18,11 +115,15 @@ if (typeof jQuery === 'undefined')
       }
 
       if (!$this.is('img')) {
-        throw new Error('LoadGo only works on img elements.')
+        const message = 'LoadGo only works on img elements.'
+        dispatchCustomEvent($this[0], 'error', { message })
+        throw new Error(message)
       }
 
       if ($this.length > 1) {
-        throw new Error('LoadGo only works on one element at a time. Try with a valid #id.')
+        const message = 'LoadGo only works on one element at a time. Try with a valid #id.'
+        dispatchCustomEvent($this[0], 'error', { message })
+        throw new Error(message)
       }
 
       // If already initialized, destroy first to prevent nested containers
@@ -249,8 +350,15 @@ if (typeof jQuery === 'undefined')
       pluginData.resizeFunction = resizeHandler
       $this.data('loadgo', pluginData)
       $(window).on('resize', resizeHandler)
+
+      dispatchCustomEvent($this[0], 'init')
     },
 
+    /**
+     * Get or set options for an already-initialised element.
+     * @param  {object} [userOptions]  Loadgo options to update. Omit to use as getter.
+     * @fires loadgo:options - Only fired when called as a setter after init.
+     */
     options: function (userOptions) {
       const $this = $(this)
       let currentOptions = $this.data('loadgo-options')
@@ -274,6 +382,8 @@ if (typeof jQuery === 'undefined')
       if (typeof options.opacity !== 'undefined') {
         options.opacity = parseFloat(options.opacity)
       }
+
+      const isUpdate = Object.keys(currentOptions).length > 0 && typeof userOptions !== 'undefined'
 
       if (Object.keys(currentOptions).length === 0) {
         currentOptions = $.extend({}, defaults, options)
@@ -303,87 +413,25 @@ if (typeof jQuery === 'undefined')
       // Store user options with default options
       $this.data('loadgo-options', currentOptions)
 
+      if (isUpdate) {
+        dispatchCustomEvent($this[0], 'options', currentOptions)
+      }
+
       return currentOptions
     },
 
     /**
      * Set progress by percentage
      * @param  {number} progress Progress value (between 0 and 100)
+     * @fires loadgo:progress
+     * @fires loadgo:complete - Only fired when progress reaches 100% outside of a loop.
      */
     setprogress: function (progress) {
-      // LoadGo expects progress number between 0 (0%) and 100 (100%).
-      if (progress < 0 || progress > 100) {
-        return
-      }
-
-      const data = $(this).data('loadgo')
-      if (typeof data === 'undefined') {
-        return
-      }
-
-      const storedData = { progress: progress }
-      const pluginOptions = $(this).loadgo('options')
-      const $overlay = data.overlay
-      const $width = data.width
-      const $height = data.height
-      const direction = pluginOptions.direction
-
-      if ($overlay) {
-        let overlayWidth, overlayHeight
-        if (direction === 'lr') {
-          // Left to right animation
-          overlayWidth = $width * (1 - progress / 100)
-          $overlay[0].style.width = `${overlayWidth}px`
-        } else if (direction === 'rl') {
-          // Right to left animation
-          overlayWidth = $width * (1 - progress / 100)
-          $overlay[0].style.width = `${overlayWidth}px`
-        } else if (direction === 'bt') {
-          // Bottom to top animation
-          overlayHeight = $height * (1 - progress / 100)
-          $overlay[0].style.height = `${overlayHeight}px`
-        } else if (direction === 'tb') {
-          // Top to bottom animation
-          overlayHeight = $height * (1 - progress / 100)
-          $overlay[0].style.height = `${overlayHeight}px`
-          $overlay[0].style.top = `${$height - overlayHeight}px`
-        }
-
-        $overlay[0].setAttribute('aria-valuenow', progress)
-        storedData.overlay = $overlay
-      } else {
-        $(this)[0].setAttribute('aria-valuenow', progress)
-        const $filter = pluginOptions.filter
-        let p
-        switch ($filter) {
-          case 'blur':
-            p = (100 - progress) / 10 // maps 0–100% progress to 10px–0px blur radius
-            $(this).css({ filter: `${$filter}(${p}px)` })
-            break
-          case 'hue-rotate':
-            p = (progress * 360) / 100
-            $(this).css({ filter: `${$filter}(${p}deg)` })
-            break
-          case 'opacity':
-            p = progress / 100
-            $(this).css({ filter: `${$filter}(${p})` })
-            break
-          default:
-            p = 1 - progress / 100
-            $(this).css({ filter: `${$filter}(${p})` })
-        }
-      }
-
-      $(this).data('loadgo', $.extend({}, data, storedData))
-
-      const onProgress = $(this).loadgo('options').onProgress
-      if (typeof onProgress === 'function') {
-        onProgress(progress)
-      }
+      _setprogress(this, progress, true)
     },
 
     /**
-     * Return current progress
+     * Return the current progress value.
      */
     getprogress: function () {
       const data = $(this).data('loadgo')
@@ -396,30 +444,41 @@ if (typeof jQuery === 'undefined')
 
     /**
      * Reset progress
+     * @fires loadgo:reset
      */
     resetprogress: function () {
-      $(this).loadgo('setprogress', 0)
+      _setprogress(this, 0, false)
+      dispatchCustomEvent(this[0], 'reset', { progress: 0 })
     },
 
     /**
-     * Overlay loops back and forth
-     * @param  {number} duration Interval duration in ms
+     * Start an indefinite back-and-forth animation loop.
+     * @param  {number} duration  Interval duration in ms
+     * @fires loadgo:start
+     * @fires loadgo:cycle - Fired each time the loop completes one full back-and-forth.
+     * @fires loadgo:error
      */
     loop: function (duration) {
       const data = $(this).data('loadgo')
 
       if (typeof data === 'undefined') {
-        console.error('Element do not have Loadgo properties.')
+        const message = 'Element do not have Loadgo properties.'
+        dispatchCustomEvent(this[0], 'error', { message })
+        console.error(message)
         return
       }
 
       if (data.interval) {
-        console.error('LoadGo requires you to stop the current loop before modifying it.')
+        const message = 'LoadGo requires you to stop the current loop before modifying it.'
+        dispatchCustomEvent(this[0], 'error', { message })
+        console.error(message)
         return
       }
 
+      dispatchCustomEvent(this[0], 'start')
+
       let toggle = true
-      const image = this
+      const image = this[0]
 
       // Store interval so we can stop it later
       data.interval = setInterval(() => {
@@ -432,6 +491,7 @@ if (typeof jQuery === 'undefined')
           data.progress -= 1
           if (data.progress <= 0) {
             toggle = true
+            dispatchCustomEvent(image, 'cycle')
           }
         }
 
@@ -443,28 +503,33 @@ if (typeof jQuery === 'undefined')
           })
         }
 
-        $(image).loadgo('setprogress', data.progress)
+        _setprogress(image, data.progress, true)
       }, duration)
     },
 
     /**
-     * Stops the loop interval and shows image
+     * Stop the loop and reveal the full image.
+     * @fires loadgo:stop
+     * @fires loadgo:error
      */
     stop: function () {
       const data = $(this).data('loadgo')
       if (typeof data === 'undefined') {
-        console.error(
-          'Trying to stop loop for a non initialized element. You have to run "init" method first.',
-        )
+        const message =
+          'Trying to stop loop for a non initialized element. You have to run "init" method first.'
+        dispatchCustomEvent(this[0], 'error', { message })
+        console.error(message)
         return
       }
 
       data.interval = clearInterval(data.interval)
-      $(this).loadgo('setprogress', 100)
+      _setprogress(this, 100, false)
+      dispatchCustomEvent(this[0], 'stop', { progress: 100 })
     },
 
     /**
-     * Remove all plugin properties
+     * Remove the overlay and restore the original DOM structure.
+     * @fires loadgo:destroy
      */
     destroy: function () {
       const $this = $(this)
@@ -493,6 +558,8 @@ if (typeof jQuery === 'undefined')
       // Remove properties
       $this.removeData('loadgo')
       $this.removeData('loadgo-options')
+
+      dispatchCustomEvent($this[0], 'destroy')
     },
   }
 

--- a/packages/core/tests/loadgo-vanilla.test.js
+++ b/packages/core/tests/loadgo-vanilla.test.js
@@ -25,6 +25,13 @@ afterEach(() => {
 
 const getOverlay = () => image.parentElement?.querySelector('.loadgo-overlay') ?? null
 
+const captureEvent = (el, type) => {
+  const events = []
+  const handler = (e) => events.push(e)
+  el.addEventListener(type, handler)
+  return { events, off: () => el.removeEventListener(type, handler) }
+}
+
 describe('JS - Initialization', () => {
   it('exposes Loadgo on window', () => {
     expect(typeof globalThis.Loadgo).toBe('object')
@@ -729,5 +736,244 @@ describe('JS - loop/stop edge cases', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('JS - Custom events: loadgo:init', () => {
+  it('fires on init()', () => {
+    const { events, off } = captureEvent(image, 'loadgo:init')
+    Loadgo.init(image)
+    off()
+    expect(events.length).toBe(1)
+  })
+
+  it('fires again on re-init', () => {
+    Loadgo.init(image)
+    const { events, off } = captureEvent(image, 'loadgo:init')
+    Loadgo.init(image)
+    off()
+    expect(events.length).toBe(1)
+  })
+})
+
+describe('JS - Custom events: loadgo:error', () => {
+  it('fires when element is not an img', () => {
+    const div = document.createElement('div')
+    div.id = 'not-img-error'
+    document.body.appendChild(div)
+    const { events, off } = captureEvent(div, 'loadgo:error')
+    try {
+      Loadgo.init(div)
+    } catch (_) {}
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.message).toMatch(/img/)
+  })
+
+  it('fires on loop() when element is not initialized', () => {
+    const { events, off } = captureEvent(image, 'loadgo:error')
+    Loadgo.loop(image, 1000)
+    off()
+    expect(events.length).toBe(1)
+  })
+
+  it('fires on loop() when already looping', () => {
+    Loadgo.init(image)
+    Loadgo.loop(image, 1000)
+    const { events, off } = captureEvent(image, 'loadgo:error')
+    Loadgo.loop(image, 1000)
+    off()
+    Loadgo.stop(image)
+    expect(events.length).toBe(1)
+  })
+
+  it('fires on stop() when element is not initialized', () => {
+    const { events, off } = captureEvent(image, 'loadgo:error')
+    Loadgo.stop(image)
+    off()
+    expect(events.length).toBe(1)
+  })
+})
+
+describe('JS - Custom events: loadgo:options', () => {
+  it('fires when options() is called as a setter after init', () => {
+    Loadgo.init(image)
+    const { events, off } = captureEvent(image, 'loadgo:options')
+    Loadgo.options(image, { bgcolor: '#FF0000' })
+    off()
+    expect(events.length).toBe(1)
+  })
+
+  it('detail contains the merged options', () => {
+    Loadgo.init(image)
+    const { events, off } = captureEvent(image, 'loadgo:options')
+    Loadgo.options(image, { bgcolor: '#FF0000' })
+    off()
+    expect(events[0].detail.bgcolor).toBe('#FF0000')
+  })
+
+  it('does not fire during init()', () => {
+    const { events, off } = captureEvent(image, 'loadgo:options')
+    Loadgo.init(image)
+    off()
+    expect(events.length).toBe(0)
+  })
+
+  it('does not fire when options() is used as a getter', () => {
+    Loadgo.init(image)
+    const { events, off } = captureEvent(image, 'loadgo:options')
+    Loadgo.options(image)
+    off()
+    expect(events.length).toBe(0)
+  })
+})
+
+describe('JS - Custom events: loadgo:progress', () => {
+  it('fires on setprogress() with correct detail', () => {
+    Loadgo.init(image)
+    const { events, off } = captureEvent(image, 'loadgo:progress')
+    Loadgo.setprogress(image, 50)
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.progress).toBe(50)
+  })
+
+  it('does not fire on resetprogress()', () => {
+    Loadgo.init(image)
+    Loadgo.setprogress(image, 50)
+    const { events, off } = captureEvent(image, 'loadgo:progress')
+    Loadgo.resetprogress(image)
+    off()
+    expect(events.length).toBe(0)
+  })
+
+  it('does not fire on stop()', () => {
+    Loadgo.init(image)
+    Loadgo.loop(image, 1000)
+    const { events, off } = captureEvent(image, 'loadgo:progress')
+    Loadgo.stop(image)
+    off()
+    expect(events.length).toBe(0)
+  })
+})
+
+describe('JS - Custom events: loadgo:complete', () => {
+  it('fires when setprogress reaches 100 outside a loop', () => {
+    Loadgo.init(image)
+    const { events, off } = captureEvent(image, 'loadgo:complete')
+    Loadgo.setprogress(image, 100)
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.progress).toBe(100)
+  })
+
+  it('does not fire for values below 100', () => {
+    Loadgo.init(image)
+    const { events, off } = captureEvent(image, 'loadgo:complete')
+    Loadgo.setprogress(image, 99)
+    off()
+    expect(events.length).toBe(0)
+  })
+
+  it('does not fire when progress reaches 100 inside a loop', () => {
+    vi.useFakeTimers()
+    try {
+      Loadgo.init(image)
+      const { events, off } = captureEvent(image, 'loadgo:complete')
+      Loadgo.loop(image, 1)
+      vi.advanceTimersByTime(105) // enough ticks to pass 100
+      off()
+      Loadgo.stop(image)
+      expect(events.length).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('JS - Custom events: loadgo:reset', () => {
+  it('fires on resetprogress() with progress 0', () => {
+    Loadgo.init(image)
+    Loadgo.setprogress(image, 50)
+    const { events, off } = captureEvent(image, 'loadgo:reset')
+    Loadgo.resetprogress(image)
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.progress).toBe(0)
+  })
+})
+
+describe('JS - Custom events: loadgo:start', () => {
+  it('fires on loop()', () => {
+    Loadgo.init(image)
+    const { events, off } = captureEvent(image, 'loadgo:start')
+    Loadgo.loop(image, 1000)
+    off()
+    Loadgo.stop(image)
+    expect(events.length).toBe(1)
+  })
+})
+
+describe('JS - Custom events: loadgo:cycle', () => {
+  it('fires when the loop completes one full back-and-forth', () => {
+    vi.useFakeTimers()
+    try {
+      Loadgo.init(image)
+      const { events, off } = captureEvent(image, 'loadgo:cycle')
+      Loadgo.loop(image, 1)
+      vi.advanceTimersByTime(200) // 100 ticks up + 100 ticks down
+      off()
+      Loadgo.stop(image)
+      expect(events.length).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fires multiple times across multiple cycles', () => {
+    vi.useFakeTimers()
+    try {
+      Loadgo.init(image)
+      const { events, off } = captureEvent(image, 'loadgo:cycle')
+      Loadgo.loop(image, 1)
+      vi.advanceTimersByTime(400) // ~2 full cycles
+      off()
+      Loadgo.stop(image)
+      expect(events.length).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('JS - Custom events: loadgo:stop', () => {
+  it('fires on stop() with progress 100', () => {
+    Loadgo.init(image)
+    Loadgo.loop(image, 1000)
+    const { events, off } = captureEvent(image, 'loadgo:stop')
+    Loadgo.stop(image)
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.progress).toBe(100)
+  })
+})
+
+describe('JS - Custom events: loadgo:destroy', () => {
+  it('fires on destroy()', () => {
+    Loadgo.init(image)
+    const { events, off } = captureEvent(image, 'loadgo:destroy')
+    Loadgo.destroy(image)
+    off()
+    expect(events.length).toBe(1)
+  })
+})
+
+describe('JS - Custom events: bubbling', () => {
+  it('events bubble up to the parent element', () => {
+    Loadgo.init(image)
+    const { events, off } = captureEvent(container, 'loadgo:progress')
+    Loadgo.setprogress(image, 40)
+    off()
+    expect(events.length).toBe(1)
   })
 })

--- a/packages/core/tests/loadgo-vanilla.test.js
+++ b/packages/core/tests/loadgo-vanilla.test.js
@@ -764,7 +764,10 @@ describe('JS - Custom events: loadgo:error', () => {
     const { events, off } = captureEvent(div, 'loadgo:error')
     try {
       Loadgo.init(div)
-    } catch (_) {}
+      // eslint-disable-next-line no-unused-vars
+    } catch (_) {
+      //
+    }
     off()
     expect(events.length).toBe(1)
     expect(events[0].detail.message).toMatch(/img/)

--- a/packages/core/tests/loadgo-vanilla.test.js
+++ b/packages/core/tests/loadgo-vanilla.test.js
@@ -804,6 +804,21 @@ describe('JS - Custom events: loadgo:error', () => {
     expect(events.length).toBe(1)
     expect(events[0].detail.message).toMatch(/set progress/)
   })
+
+  it('fires on resetprogress() when element is not initialized', () => {
+    const { events, off } = captureEvent(image, 'loadgo:error')
+    Loadgo.resetprogress(image)
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.message).toMatch(/reset progress/)
+  })
+
+  it('does not fire loadgo:reset when element is not initialized', () => {
+    const { events, off } = captureEvent(image, 'loadgo:reset')
+    Loadgo.resetprogress(image)
+    off()
+    expect(events.length).toBe(0)
+  })
 })
 
 describe('JS - Custom events: loadgo:options', () => {

--- a/packages/core/tests/loadgo-vanilla.test.js
+++ b/packages/core/tests/loadgo-vanilla.test.js
@@ -796,6 +796,14 @@ describe('JS - Custom events: loadgo:error', () => {
     off()
     expect(events.length).toBe(1)
   })
+
+  it('fires on setprogress() when element is not initialized', () => {
+    const { events, off } = captureEvent(image, 'loadgo:error')
+    Loadgo.setprogress(image, 50)
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.message).toMatch(/set progress/)
+  })
 })
 
 describe('JS - Custom events: loadgo:options', () => {

--- a/packages/core/tests/loadgo.test.js
+++ b/packages/core/tests/loadgo.test.js
@@ -23,6 +23,13 @@ afterEach(() => {
 
 const getOverlay = () => $image.siblings('.loadgo-overlay').first()
 
+const captureEvent = (el, type) => {
+  const events = []
+  const handler = (e) => events.push(e)
+  el.addEventListener(type, handler)
+  return { events, off: () => el.removeEventListener(type, handler) }
+}
+
 describe('jQuery - Initialization', () => {
   it('exposes $.fn.loadgo as a function', () => {
     expect(typeof $.fn.loadgo).toBe('function')
@@ -704,5 +711,244 @@ describe('jQuery - loop/stop edge cases', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('jQuery - Custom events: loadgo:init', () => {
+  it('fires on init()', () => {
+    const { events, off } = captureEvent($image[0], 'loadgo:init')
+    $image.loadgo()
+    off()
+    expect(events.length).toBe(1)
+  })
+
+  it('fires again on re-init', () => {
+    $image.loadgo()
+    const { events, off } = captureEvent($image[0], 'loadgo:init')
+    $image.loadgo()
+    off()
+    expect(events.length).toBe(1)
+  })
+})
+
+describe('jQuery - Custom events: loadgo:error', () => {
+  it('fires when element is not an img', () => {
+    const div = document.createElement('div')
+    div.id = 'not-img-error'
+    document.body.appendChild(div)
+    const { events, off } = captureEvent(div, 'loadgo:error')
+    try {
+      $(div).loadgo()
+    } catch (_) {}
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.message).toMatch(/img/)
+  })
+
+  it('fires on loop() when element is not initialized', () => {
+    const { events, off } = captureEvent($image[0], 'loadgo:error')
+    $image.loadgo('loop', 1000)
+    off()
+    expect(events.length).toBe(1)
+  })
+
+  it('fires on loop() when already looping', () => {
+    $image.loadgo()
+    $image.loadgo('loop', 1000)
+    const { events, off } = captureEvent($image[0], 'loadgo:error')
+    $image.loadgo('loop', 1000)
+    off()
+    $image.loadgo('stop')
+    expect(events.length).toBe(1)
+  })
+
+  it('fires on stop() when element is not initialized', () => {
+    const { events, off } = captureEvent($image[0], 'loadgo:error')
+    $image.loadgo('stop')
+    off()
+    expect(events.length).toBe(1)
+  })
+})
+
+describe('jQuery - Custom events: loadgo:options', () => {
+  it('fires when options() is called as a setter after init', () => {
+    $image.loadgo()
+    const { events, off } = captureEvent($image[0], 'loadgo:options')
+    $image.loadgo('options', { bgcolor: '#FF0000' })
+    off()
+    expect(events.length).toBe(1)
+  })
+
+  it('detail contains the merged options', () => {
+    $image.loadgo()
+    const { events, off } = captureEvent($image[0], 'loadgo:options')
+    $image.loadgo('options', { bgcolor: '#FF0000' })
+    off()
+    expect(events[0].detail.bgcolor).toBe('#FF0000')
+  })
+
+  it('does not fire during init()', () => {
+    const { events, off } = captureEvent($image[0], 'loadgo:options')
+    $image.loadgo()
+    off()
+    expect(events.length).toBe(0)
+  })
+
+  it('does not fire when options() is used as a getter', () => {
+    $image.loadgo()
+    const { events, off } = captureEvent($image[0], 'loadgo:options')
+    $image.loadgo('options')
+    off()
+    expect(events.length).toBe(0)
+  })
+})
+
+describe('jQuery - Custom events: loadgo:progress', () => {
+  it('fires on setprogress() with correct detail', () => {
+    $image.loadgo()
+    const { events, off } = captureEvent($image[0], 'loadgo:progress')
+    $image.loadgo('setprogress', 50)
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.progress).toBe(50)
+  })
+
+  it('does not fire on resetprogress()', () => {
+    $image.loadgo()
+    $image.loadgo('setprogress', 50)
+    const { events, off } = captureEvent($image[0], 'loadgo:progress')
+    $image.loadgo('resetprogress')
+    off()
+    expect(events.length).toBe(0)
+  })
+
+  it('does not fire on stop()', () => {
+    $image.loadgo()
+    $image.loadgo('loop', 1000)
+    const { events, off } = captureEvent($image[0], 'loadgo:progress')
+    $image.loadgo('stop')
+    off()
+    expect(events.length).toBe(0)
+  })
+})
+
+describe('jQuery - Custom events: loadgo:complete', () => {
+  it('fires when setprogress reaches 100 outside a loop', () => {
+    $image.loadgo()
+    const { events, off } = captureEvent($image[0], 'loadgo:complete')
+    $image.loadgo('setprogress', 100)
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.progress).toBe(100)
+  })
+
+  it('does not fire for values below 100', () => {
+    $image.loadgo()
+    const { events, off } = captureEvent($image[0], 'loadgo:complete')
+    $image.loadgo('setprogress', 99)
+    off()
+    expect(events.length).toBe(0)
+  })
+
+  it('does not fire when progress reaches 100 inside a loop', () => {
+    vi.useFakeTimers()
+    try {
+      $image.loadgo()
+      const { events, off } = captureEvent($image[0], 'loadgo:complete')
+      $image.loadgo('loop', 1)
+      vi.advanceTimersByTime(105) // enough ticks to pass 100
+      off()
+      $image.loadgo('stop')
+      expect(events.length).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('jQuery - Custom events: loadgo:reset', () => {
+  it('fires on resetprogress() with progress 0', () => {
+    $image.loadgo()
+    $image.loadgo('setprogress', 50)
+    const { events, off } = captureEvent($image[0], 'loadgo:reset')
+    $image.loadgo('resetprogress')
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.progress).toBe(0)
+  })
+})
+
+describe('jQuery - Custom events: loadgo:start', () => {
+  it('fires on loop()', () => {
+    $image.loadgo()
+    const { events, off } = captureEvent($image[0], 'loadgo:start')
+    $image.loadgo('loop', 1000)
+    off()
+    $image.loadgo('stop')
+    expect(events.length).toBe(1)
+  })
+})
+
+describe('jQuery - Custom events: loadgo:cycle', () => {
+  it('fires when the loop completes one full back-and-forth', () => {
+    vi.useFakeTimers()
+    try {
+      $image.loadgo()
+      const { events, off } = captureEvent($image[0], 'loadgo:cycle')
+      $image.loadgo('loop', 1)
+      vi.advanceTimersByTime(200) // 100 ticks up + 100 ticks down
+      off()
+      $image.loadgo('stop')
+      expect(events.length).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fires multiple times across multiple cycles', () => {
+    vi.useFakeTimers()
+    try {
+      $image.loadgo()
+      const { events, off } = captureEvent($image[0], 'loadgo:cycle')
+      $image.loadgo('loop', 1)
+      vi.advanceTimersByTime(400) // ~2 full cycles
+      off()
+      $image.loadgo('stop')
+      expect(events.length).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('jQuery - Custom events: loadgo:stop', () => {
+  it('fires on stop() with progress 100', () => {
+    $image.loadgo()
+    $image.loadgo('loop', 1000)
+    const { events, off } = captureEvent($image[0], 'loadgo:stop')
+    $image.loadgo('stop')
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.progress).toBe(100)
+  })
+})
+
+describe('jQuery - Custom events: loadgo:destroy', () => {
+  it('fires on destroy()', () => {
+    $image.loadgo()
+    const { events, off } = captureEvent($image[0], 'loadgo:destroy')
+    $image.loadgo('destroy')
+    off()
+    expect(events.length).toBe(1)
+  })
+})
+
+describe('jQuery - Custom events: bubbling', () => {
+  it('events bubble up to the parent element', () => {
+    $image.loadgo()
+    const { events, off } = captureEvent($container[0], 'loadgo:progress')
+    $image.loadgo('setprogress', 40)
+    off()
+    expect(events.length).toBe(1)
   })
 })

--- a/packages/core/tests/loadgo.test.js
+++ b/packages/core/tests/loadgo.test.js
@@ -779,6 +779,21 @@ describe('jQuery - Custom events: loadgo:error', () => {
     expect(events.length).toBe(1)
     expect(events[0].detail.message).toMatch(/set progress/)
   })
+
+  it('fires on resetprogress() when element is not initialized', () => {
+    const { events, off } = captureEvent($image[0], 'loadgo:error')
+    $image.loadgo('resetprogress')
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.message).toMatch(/reset progress/)
+  })
+
+  it('does not fire loadgo:reset when element is not initialized', () => {
+    const { events, off } = captureEvent($image[0], 'loadgo:reset')
+    $image.loadgo('resetprogress')
+    off()
+    expect(events.length).toBe(0)
+  })
 })
 
 describe('jQuery - Custom events: loadgo:options', () => {

--- a/packages/core/tests/loadgo.test.js
+++ b/packages/core/tests/loadgo.test.js
@@ -771,6 +771,14 @@ describe('jQuery - Custom events: loadgo:error', () => {
     off()
     expect(events.length).toBe(1)
   })
+
+  it('fires on setprogress() when element is not initialized', () => {
+    const { events, off } = captureEvent($image[0], 'loadgo:error')
+    $image.loadgo('setprogress', 50)
+    off()
+    expect(events.length).toBe(1)
+    expect(events[0].detail.message).toMatch(/set progress/)
+  })
 })
 
 describe('jQuery - Custom events: loadgo:options', () => {

--- a/packages/core/tests/loadgo.test.js
+++ b/packages/core/tests/loadgo.test.js
@@ -739,7 +739,10 @@ describe('jQuery - Custom events: loadgo:error', () => {
     const { events, off } = captureEvent(div, 'loadgo:error')
     try {
       $(div).loadgo()
-    } catch (_) {}
+      // eslint-disable-next-line no-unused-vars
+    } catch (_) {
+      //
+    }
     off()
     expect(events.length).toBe(1)
     expect(events[0].detail.message).toMatch(/img/)

--- a/packages/core/types/loadgo-vanilla.d.ts
+++ b/packages/core/types/loadgo-vanilla.d.ts
@@ -78,14 +78,14 @@ export interface LoadgoDetail {
 
 export interface LoadgoEventMap {
   'loadgo:complete': CustomEvent<LoadgoDetail>
-  'loadgo:cycle': CustomEvent<undefined>
-  'loadgo:destroy': CustomEvent<undefined>
+  'loadgo:cycle': CustomEvent<null>
+  'loadgo:destroy': CustomEvent<null>
   'loadgo:error': CustomEvent<{ message: string }>
-  'loadgo:init': CustomEvent<undefined>
+  'loadgo:init': CustomEvent<null>
   'loadgo:options': CustomEvent<LoadgoOptions>
   'loadgo:progress': CustomEvent<LoadgoDetail>
   'loadgo:reset': CustomEvent<LoadgoDetail>
-  'loadgo:start': CustomEvent<undefined>
+  'loadgo:start': CustomEvent<null>
   'loadgo:stop': CustomEvent<LoadgoDetail>
 }
 

--- a/packages/core/types/loadgo-vanilla.d.ts
+++ b/packages/core/types/loadgo-vanilla.d.ts
@@ -26,26 +26,84 @@ export interface LoadgoOptions {
 }
 
 export interface LoadgoAPI {
-  /** Initialise LoadGo on an `<img>` element. */
+  /**
+   * Initialise LoadGo on an `<img>` element.
+   * @fires loadgo:init
+   * @fires loadgo:error
+   */
   init(element: HTMLImageElement, options?: LoadgoOptions): void
-  /** Get or set options for an already-initialised element. */
+  /**
+   * Get or set options for an already-initialised element.
+   * @fires loadgo:options - Only fired when called as a setter after init.
+   */
   options(element: HTMLImageElement, options?: LoadgoOptions): LoadgoOptions
-  /** Set progress (0–100). */
+  /** 
+   * Set progress (0–100). 
+   * @fires loadgo:progress
+   * @fires loadgo:complete - Only fired when progress reaches 100% outside of a loop.
+   */
   setprogress(element: HTMLImageElement, progress: number): void
   /** Return the current progress value. */
   getprogress(element: HTMLImageElement): number
-  /** Reset progress back to 0. */
+  /** 
+   * Reset progress back to 0. 
+   * @fires loadgo:reset
+   */
   resetprogress(element: HTMLImageElement): void
-  /** Start an indefinite back-and-forth animation loop. */
+  /**
+   * Start an indefinite back-and-forth animation loop.
+   * @fires loadgo:start
+   * @fires loadgo:cycle - Fired each time the loop completes one full back-and-forth.
+   * @fires loadgo:error
+   */
   loop(element: HTMLImageElement, duration: number): void
-  /** Stop the loop and reveal the full image. */
+  /**
+   * Stop the loop and reveal the full image.
+   * @fires loadgo:stop
+   * @fires loadgo:error
+   */
   stop(element: HTMLImageElement): void
-  /** Remove the overlay and restore the original DOM structure. */
+  /**
+   * Remove the overlay and restore the original DOM structure.
+   * @fires loadgo:destroy
+   */
   destroy(element: HTMLImageElement): void
 }
 
 export declare const Loadgo: LoadgoAPI
 
+export interface LoadgoDetail {
+  progress: number
+}
+
+export interface LoadgoEventMap {
+  'loadgo:complete': CustomEvent<LoadgoDetail>
+  'loadgo:cycle': CustomEvent<undefined>
+  'loadgo:destroy': CustomEvent<undefined>
+  'loadgo:error': CustomEvent<{ message: string }>
+  'loadgo:init': CustomEvent<undefined>
+  'loadgo:options': CustomEvent<LoadgoOptions>
+  'loadgo:progress': CustomEvent<LoadgoDetail>
+  'loadgo:reset': CustomEvent<LoadgoDetail>
+  'loadgo:start': CustomEvent<undefined>
+  'loadgo:stop': CustomEvent<LoadgoDetail>
+}
+
 declare global {
   const Loadgo: LoadgoAPI
+
+  interface HTMLImageElementEventMap extends LoadgoEventMap {}
+
+  interface HTMLImageElement {
+    addEventListener<K extends keyof LoadgoEventMap>(
+      type: K,
+      listener: (this: HTMLImageElement, ev: LoadgoEventMap[K]) => any,
+      options?: boolean | AddEventListenerOptions
+    ): void
+    removeEventListener<K extends keyof LoadgoEventMap>(
+      type: K,
+      listener: (this: HTMLImageElement, ev: LoadgoEventMap[K]) => any,
+      options?: boolean | EventListenerOptions
+    ): void
+  }
 }

--- a/packages/core/types/loadgo.d.ts
+++ b/packages/core/types/loadgo.d.ts
@@ -1,25 +1,63 @@
-import type { LoadgoOptions } from './loadgo-vanilla'
+import type { LoadgoOptions, LoadgoEventMap } from './loadgo-vanilla'
 
 declare global {
   interface JQuery {
-    /** Initialise LoadGo with optional options (shorthand for `'init'`). */
+    /**
+     * Initialise LoadGo with optional options (shorthand for `'init'`).
+     * @fires loadgo:init
+     */
     loadgo(options?: LoadgoOptions): JQuery
-    /** Initialise LoadGo on the selected `<img>` element. */
+    /**
+     * Initialise LoadGo on the selected `<img>` element.
+     * @fires loadgo:init
+     * @fires loadgo:error
+     */
     loadgo(method: 'init', options?: LoadgoOptions): JQuery
-    /** Get or set options for an already-initialised element. */
+    /**
+     * Get or set options for an already-initialised element.
+     * @fires loadgo:options - Only fired when called as a setter after init.
+     */
     loadgo(method: 'options', options?: LoadgoOptions): LoadgoOptions
-    /** Set progress (0–100). */
+    /**
+     * Set progress (0–100).
+     * @fires loadgo:progress
+     * @fires loadgo:complete - Only fired when progress reaches 100% outside of a loop.
+     */
     loadgo(method: 'setprogress', progress: number): JQuery
     /** Return the current progress value. */
     loadgo(method: 'getprogress'): number
-    /** Reset progress back to 0. */
+    /**
+     * Reset progress back to 0.
+     * @fires loadgo:reset
+     */
     loadgo(method: 'resetprogress'): JQuery
-    /** Start an indefinite back-and-forth animation loop. */
+    /**
+     * Start an indefinite back-and-forth animation loop.
+     * @fires loadgo:start
+     * @fires loadgo:cycle - Fired each time the loop completes one full back-and-forth.
+     * @fires loadgo:error
+     */
     loadgo(method: 'loop', duration: number): JQuery
-    /** Stop the loop and reveal the full image. */
+    /**
+     * Stop the loop and reveal the full image.
+     * @fires loadgo:stop
+     * @fires loadgo:error
+     */
     loadgo(method: 'stop'): JQuery
-    /** Remove the overlay and restore the original DOM structure. */
+    /**
+     * Remove the overlay and restore the original DOM structure.
+     * @fires loadgo:destroy
+     */
     loadgo(method: 'destroy'): JQuery
+
+    on<K extends keyof LoadgoEventMap>(
+      events: K,
+      handler: (this: HTMLImageElement, ev: LoadgoEventMap[K]) => any
+    ): this
+    off<K extends keyof LoadgoEventMap>(
+      events: K,
+      handler?: (this: HTMLImageElement, ev: LoadgoEventMap[K]) => any
+    ): this
   }
 }
 


### PR DESCRIPTION
https://github.com/franverona/loadgo/issues/22

- Native CustomEvent dispatching across all lifecycle methods in both implementations
- Full TypeScript types (LoadgoEventMap, augmented HTMLImageElement.addEventListener)
- Interactive demo pages for jQuery and Vanilla JS
- README and CLAUDE.md documentation
- $filter renamed to filter in jQuery _setprogress
- loadgo:options detail is now a shallow copy (prevents internal state mutation)
- setprogress() dispatches loadgo:error on uninitialized elements
- resetprogress() guards against uninitialized elements (prevented spurious loadgo:reset)
- Tests for all new error paths (263 passing)

## Events

| Event | Fires when | `event.detail` |
| --- | --- | --- |
| `loadgo:init` | `init()` completes | — |
| `loadgo:error` | invalid usage (non-`img` element, loop/stop on uninitialized, double loop) | `{ message: string }` |
| `loadgo:options` | `options()` is called as a setter after init | merged `LoadgoOptions` object |
| `loadgo:progress` | `setprogress()` is called | `{ progress: number }` |
| `loadgo:complete` | progress reaches 100 **outside** of a loop | `{ progress: 100 }` |
| `loadgo:reset` | `resetprogress()` is called | `{ progress: 0 }` |
| `loadgo:start` | `loop()` starts | — |
| `loadgo:cycle` | loop completes one full back-and-forth (bounces back to 0) | — |
| `loadgo:stop` | `stop()` is called | `{ progress: 100 }` |
| `loadgo:destroy` | `destroy()` completes | — |