### PR TITLE
feat: pause and resume methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,16 @@ Both implementations dispatch native DOM `CustomEvent`s (not jQuery `.trigger()`
 - `loadgo:complete` is guarded by `!data.interval` — it never fires inside a loop even when progress hits 100.
 - `loadgo:options` is guarded by an `isUpdate` flag computed before the `if/else` branch. It fires only on the update path (existing options + user-provided options), not during first-time init and not when `options()` is used as a getter.
 - Events with no payload (`loadgo:init`, `loadgo:start`, `loadgo:cycle`, `loadgo:destroy`) are dispatched without a `detail` argument — the Web API defaults `event.detail` to `null`. The TypeScript types use `CustomEvent<null>` accordingly.
+- `loadgo:pause` and `loadgo:resume` carry `{ progress: number }` as their detail. They fire only when the state actually changes (pause when interval exists, resume when `paused` flag is true). Both are no-ops otherwise — no event is dispatched.
+
+## pause() / resume() internals
+
+`loop()` stores three extra fields in element state: `loopDuration` (the interval ms), `loopToggle` (the current direction: `true` = going up, `false` = going down), and `paused` (boolean). `loopToggle` is synced on every tick so `pause()` can snapshot it.
+
+- `pause()`: calls `clearInterval`, nulls `interval`, sets `paused = true`.
+- `resume()`: restarts `setInterval` with the saved `loopDuration` and `loopToggle`, sets `paused = false`.
+- Vanilla version extracts a shared `_startLoopInterval(element, idx, toggle)` helper used by both `loop()` and `resume()` to avoid duplication.
+- `stop()` is unaffected — it does not check `paused` and always sets progress to 100.
 
 ## jQuery 4 compatibility notes
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   - [Accessibility](#accessibility)
   - [Methods](#methods)
   - [Custom events](#custom-events)
+  - [Pause and resume a loop](#pause-and-resume-a-loop)
 - [Real-world example](#real-world-example)
 - [Examples](#examples)
 - [Tests](#tests)
@@ -331,6 +332,36 @@ Loadgo.stop(document.getElementById('logo'));
 
 ---
 
+#### Pause loop
+**`$element.loadgo('pause')`** | **`Loadgo.pause(<element>)`**
+
+Pauses a running loop, freezing the animation at the current progress. The direction toggle state is also preserved so `resume()` continues smoothly in the same direction. No-op if the element is not currently looping.
+
+```js
+// jQuery
+$('#logo').loadgo('pause');
+
+// Pure JavaScript
+Loadgo.pause(document.getElementById('logo'));
+```
+
+---
+
+#### Resume loop
+**`$element.loadgo('resume')`** | **`Loadgo.resume(<element>)`**
+
+Resumes a paused loop from the exact point where `pause()` was called. No-op if the element is not paused.
+
+```js
+// jQuery
+$('#logo').loadgo('resume');
+
+// Pure JavaScript
+Loadgo.resume(document.getElementById('logo'));
+```
+
+---
+
 #### Destroy
 **`$element.loadgo('destroy')`** | **`Loadgo.destroy(<element>)`**
 
@@ -388,6 +419,8 @@ document.getElementById('logo').addEventListener('loadgo:error', (e) => {
 | `loadgo:reset` | `resetprogress()` is called | `{ progress: 0 }` |
 | `loadgo:start` | `loop()` starts | — |
 | `loadgo:cycle` | loop completes one full back-and-forth (bounces back to 0) | — |
+| `loadgo:pause` | `pause()` is called on a running loop | `{ progress: number }` |
+| `loadgo:resume` | `resume()` restarts a paused loop | `{ progress: number }` |
 | `loadgo:stop` | `stop()` is called | `{ progress: 100 }` |
 | `loadgo:destroy` | `destroy()` completes | — |
 
@@ -414,6 +447,33 @@ logo.addEventListener('loadgo:init', (e) => {
   // e.detail is null — events with no payload have CustomEvent<null>
 })
 ```
+
+### Pause and resume a loop
+
+Use `pause()` and `resume()` to freeze and restart a `loop()` animation without resetting progress. A common use case is pausing when the tab is hidden and resuming when the user returns:
+
+```js
+// jQuery
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    $('#logo').loadgo('pause')
+  } else {
+    $('#logo').loadgo('resume')
+  }
+})
+
+// Pure JavaScript
+document.addEventListener('visibilitychange', () => {
+  const el = document.getElementById('logo')
+  if (document.hidden) {
+    Loadgo.pause(el)
+  } else {
+    Loadgo.resume(el)
+  }
+})
+```
+
+`stop()` still works as before — it clears the interval and sets progress to 100, regardless of whether the loop was paused.
 
 ---
 

--- a/examples/javascript/index.html
+++ b/examples/javascript/index.html
@@ -346,6 +346,30 @@ spidermanGrayscale.onload = function () {
           </div>
         </div>
 
+        <!-- Example 7 -->
+        <h3 class="text-xl font-semibold mt-10 mb-2">Example #7: pause() and resume()</h3>
+        <p class="text-gray-700 mb-4">
+          Loop the animation with <code class="bg-gray-100 px-1 rounded">loop()</code>, then freeze it mid-animation with
+          <code class="bg-gray-100 px-1 rounded">pause()</code> and pick it back up with
+          <code class="bg-gray-100 px-1 rounded">resume()</code> — progress and direction are preserved exactly.
+        </p>
+        <div class="flex justify-center mb-4">
+          <pre class="bg-gray-100 rounded p-4 font-mono text-sm w-full max-w-lg overflow-x-auto">Loadgo.init(el);
+Loadgo.loop(el, 10);
+Loadgo.pause(el);
+Loadgo.resume(el);
+Loadgo.stop(el);</pre>
+        </div>
+        <div class="flex justify-center mb-4">
+          <img id="loop-pause" src="../logos/disney.png" alt="Disney Logo" class="max-w-full h-auto mx-auto logo" />
+        </div>
+        <div class="text-center space-x-2">
+          <button id="btn-loop-start" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700" onclick="pauseDemo('start')">Start loop</button>
+          <button id="btn-loop-pause" class="px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600 disabled:opacity-40" onclick="pauseDemo('pause')" disabled>Pause</button>
+          <button id="btn-loop-resume" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-40" onclick="pauseDemo('resume')" disabled>Resume</button>
+          <button id="btn-loop-stop" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-40" onclick="pauseDemo('stop')" disabled>Stop</button>
+        </div>
+
         <hr class="mt-10 border-gray-200" />
       </div>
     </div>

--- a/examples/javascript/main.js
+++ b/examples/javascript/main.js
@@ -39,6 +39,36 @@ function playThresholdDemo() {
   }, 300)
 }
 
+function pauseDemo(action) {
+  const el = document.getElementById('loop-pause')
+  const btnStart = document.getElementById('btn-loop-start')
+  const btnPause = document.getElementById('btn-loop-pause')
+  const btnResume = document.getElementById('btn-loop-resume')
+  const btnStop = document.getElementById('btn-loop-stop')
+
+  if (action === 'start') {
+    Loadgo.loop(el, 10)
+    btnStart.disabled = true
+    btnPause.disabled = false
+    btnResume.disabled = true
+    btnStop.disabled = false
+  } else if (action === 'pause') {
+    Loadgo.pause(el)
+    btnPause.disabled = true
+    btnResume.disabled = false
+  } else if (action === 'resume') {
+    Loadgo.resume(el)
+    btnPause.disabled = false
+    btnResume.disabled = true
+  } else if (action === 'stop') {
+    Loadgo.stop(el)
+    btnStart.disabled = false
+    btnPause.disabled = true
+    btnResume.disabled = true
+    btnStop.disabled = true
+  }
+}
+
 function playDemo(id, index) {
   const image = document.getElementById(id)
   const demoMsg = document.getElementById(`demo-msg-${index}`)
@@ -180,4 +210,11 @@ window.onload = () => {
       },
     })
   }
+
+  // Example #7
+  const loopPause = document.getElementById('loop-pause')
+  loopPause.onload = () => {
+    Loadgo.init(loopPause)
+  }
+  if (loopPause.complete) loopPause.onload()
 }

--- a/examples/jquery/index.html
+++ b/examples/jquery/index.html
@@ -292,6 +292,30 @@ $('#spidermanGrayscale').loadgo({
           </div>
         </div>
 
+        <!-- Example 7 -->
+        <h3 class="text-xl font-semibold mt-10 mb-2">Example #7: pause() and resume()</h3>
+        <p class="text-gray-700 mb-4">
+          Loop the animation with <code class="bg-gray-100 px-1 rounded">loop()</code>, then freeze it mid-animation with
+          <code class="bg-gray-100 px-1 rounded">pause()</code> and pick it back up with
+          <code class="bg-gray-100 px-1 rounded">resume()</code> — progress and direction are preserved exactly.
+        </p>
+        <div class="flex justify-center mb-4">
+          <pre class="bg-gray-100 rounded p-4 font-mono text-sm w-full max-w-lg overflow-x-auto">$('#loop-pause').loadgo();
+$('#loop-pause').loadgo('loop', 10);
+$('#loop-pause').loadgo('pause');
+$('#loop-pause').loadgo('resume');
+$('#loop-pause').loadgo('stop');</pre>
+        </div>
+        <div class="flex justify-center mb-4">
+          <img id="loop-pause" src="../logos/disney.png" alt="Disney Logo" class="max-w-full h-auto mx-auto logo" />
+        </div>
+        <div class="text-center space-x-2">
+          <button id="btn-loop-start" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700" onclick="pauseDemo('start')">Start loop</button>
+          <button id="btn-loop-pause" class="px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600 disabled:opacity-40" onclick="pauseDemo('pause')" disabled>Pause</button>
+          <button id="btn-loop-resume" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-40" onclick="pauseDemo('resume')" disabled>Resume</button>
+          <button id="btn-loop-stop" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-40" onclick="pauseDemo('stop')" disabled>Stop</button>
+        </div>
+
         <hr class="mt-10 border-gray-200" />
       </div>
     </div>

--- a/examples/jquery/main.js
+++ b/examples/jquery/main.js
@@ -69,6 +69,35 @@ function playThresholdDemo() {
   }, 300)
 }
 
+function pauseDemo(action) {
+  const btnStart = document.getElementById('btn-loop-start')
+  const btnPause = document.getElementById('btn-loop-pause')
+  const btnResume = document.getElementById('btn-loop-resume')
+  const btnStop = document.getElementById('btn-loop-stop')
+
+  if (action === 'start') {
+    $('#loop-pause').loadgo('loop', 10)
+    btnStart.disabled = true
+    btnPause.disabled = false
+    btnResume.disabled = true
+    btnStop.disabled = false
+  } else if (action === 'pause') {
+    $('#loop-pause').loadgo('pause')
+    btnPause.disabled = true
+    btnResume.disabled = false
+  } else if (action === 'resume') {
+    $('#loop-pause').loadgo('resume')
+    btnPause.disabled = false
+    btnResume.disabled = true
+  } else if (action === 'stop') {
+    $('#loop-pause').loadgo('stop')
+    btnStart.disabled = false
+    btnPause.disabled = true
+    btnResume.disabled = true
+    btnStop.disabled = true
+  }
+}
+
 $(document).ready(() => {
   // Example #1
   $('#disney')
@@ -200,6 +229,15 @@ $(document).ready(() => {
           100: () => showStatus('Done!'),
         },
       })
+    })
+    .each((_, el) => {
+      if (el.complete) $(el).trigger('load')
+    })
+
+  // Example #7
+  $('#loop-pause')
+    .on('load', () => {
+      $('#loop-pause').loadgo()
     })
     .each((_, el) => {
       if (el.complete) $(el).trigger('load')

--- a/packages/core/loadgo-vanilla.js
+++ b/packages/core/loadgo-vanilla.js
@@ -59,8 +59,10 @@
     error: 'loadgo:error',
     init: 'loadgo:init',
     options: 'loadgo:options',
+    pause: 'loadgo:pause',
     progress: 'loadgo:progress',
     reset: 'loadgo:reset',
+    resume: 'loadgo:resume',
     start: 'loadgo:start',
     stop: 'loadgo:stop',
   }
@@ -179,6 +181,31 @@
 
   // Array to store all Loadgo elements
   const domElements = []
+
+  // Starts (or restarts) the loop interval for a given element index with the given toggle state.
+  const _startLoopInterval = (element, idx, initialToggle) => {
+    let t = initialToggle
+    return setInterval(() => {
+      if (t) {
+        domElements[idx].properties.progress += 1
+        if (domElements[idx].properties.progress >= 100) {
+          t = false
+        }
+      } else {
+        domElements[idx].properties.progress -= 1
+        if (domElements[idx].properties.progress <= 0) {
+          t = true
+          dispatchCustomEvent(element, 'cycle')
+        }
+      }
+      domElements[idx].properties.loopToggle = t
+      const loopOverlay = document.getElementById(domElements[idx].properties.overlay)
+      if (loopOverlay) {
+        loopOverlay.style.transition = 'none'
+      }
+      _setprogress(element, domElements[idx].properties.progress, true)
+    }, domElements[idx].properties.loopDuration)
+  }
 
   // Loadgo default options
   const defaultOptions = {
@@ -608,32 +635,10 @@
 
     dispatchCustomEvent(element, 'start')
 
-    // Store interval so we can stop it later
-    let toggle = true
     const domIndex = getIndex(element.id)
-    domElements[domIndex].properties.interval = setInterval(() => {
-      if (toggle) {
-        domElements[domIndex].properties.progress += 1
-        if (domElements[domIndex].properties.progress >= 100) {
-          toggle = false
-        }
-      } else {
-        domElements[domIndex].properties.progress -= 1
-        if (domElements[domIndex].properties.progress <= 0) {
-          toggle = true
-          dispatchCustomEvent(element, 'cycle')
-        }
-      }
-      // Remove transition animation
-      // Can be replaced with animated: false in the initializer
-      const loopOverlay = document.getElementById(domElements[domIndex].properties.overlay)
-      if (loopOverlay) {
-        loopOverlay.style.transition = 'none'
-      }
-
-      const progress = domElements[domIndex].properties.progress
-      _setprogress(element, progress, true)
-    }, duration)
+    domElements[domIndex].properties.loopDuration = duration
+    domElements[domIndex].properties.loopToggle = true
+    domElements[domIndex].properties.interval = _startLoopInterval(element, domIndex, true)
   }
 
   /**
@@ -660,6 +665,60 @@
     domElements[idx].properties.interval = null
     _setprogress(element, 100, false)
     dispatchCustomEvent(element, 'stop', { progress: 100 })
+  }
+
+  /**
+   * Pause the loop, preserving the current progress and direction state.
+   * No-op if the element is not currently looping.
+   * @param  {HTMLImageElement} element  DOM element using document.getElementById
+   * @fires loadgo:pause
+   */
+  Loadgo.pause = function (element) {
+    if (!elementIsValid(element)) {
+      return
+    }
+
+    const idx = getIndex(element.id)
+    if (idx === -1) {
+      return
+    }
+
+    const data = domElements[idx].properties
+    if (!data.interval) {
+      return
+    }
+
+    clearInterval(data.interval)
+    data.interval = null
+    data.paused = true
+    dispatchCustomEvent(element, 'pause', { progress: data.progress })
+  }
+
+  /**
+   * Resume a paused loop, continuing from where it left off.
+   * No-op if the element is not paused.
+   * @param  {HTMLImageElement} element  DOM element using document.getElementById
+   * @fires loadgo:resume
+   */
+  Loadgo.resume = function (element) {
+    if (!elementIsValid(element)) {
+      return
+    }
+
+    const idx = getIndex(element.id)
+    if (idx === -1) {
+      return
+    }
+
+    const data = domElements[idx].properties
+    if (!data.paused) {
+      return
+    }
+
+    data.paused = false
+    const toggle = data.loopToggle !== undefined ? data.loopToggle : true
+    data.interval = _startLoopInterval(element, idx, toggle)
+    dispatchCustomEvent(element, 'resume', { progress: data.progress })
   }
 
   /**

--- a/packages/core/loadgo.js
+++ b/packages/core/loadgo.js
@@ -16,8 +16,10 @@ if (typeof jQuery === 'undefined')
     error: 'loadgo:error',
     init: 'loadgo:init',
     options: 'loadgo:options',
+    pause: 'loadgo:pause',
     progress: 'loadgo:progress',
     reset: 'loadgo:reset',
+    resume: 'loadgo:resume',
     start: 'loadgo:start',
     stop: 'loadgo:stop',
   }
@@ -513,20 +515,20 @@ if (typeof jQuery === 'undefined')
 
       dispatchCustomEvent(this[0], 'start')
 
-      let toggle = true
       const image = this[0]
+      data.loopDuration = duration
+      data.loopToggle = true
 
-      // Store interval so we can stop it later
       data.interval = setInterval(() => {
-        if (toggle) {
+        if (data.loopToggle) {
           data.progress += 1
           if (data.progress >= 100) {
-            toggle = false
+            data.loopToggle = false
           }
         } else {
           data.progress -= 1
           if (data.progress <= 0) {
-            toggle = true
+            data.loopToggle = true
             dispatchCustomEvent(image, 'cycle')
           }
         }
@@ -561,6 +563,61 @@ if (typeof jQuery === 'undefined')
       data.interval = clearInterval(data.interval)
       _setprogress(this, 100, false)
       dispatchCustomEvent(this[0], 'stop', { progress: 100 })
+    },
+
+    /**
+     * Pause the loop, preserving the current progress and direction state.
+     * No-op if the element is not currently looping.
+     * @fires loadgo:pause
+     */
+    pause: function () {
+      const data = $(this).data('loadgo')
+      if (typeof data === 'undefined' || !data.interval) {
+        return
+      }
+
+      clearInterval(data.interval)
+      data.interval = null
+      data.paused = true
+      dispatchCustomEvent(this[0], 'pause', { progress: data.progress })
+    },
+
+    /**
+     * Resume a paused loop, continuing from where it left off.
+     * No-op if the element is not paused.
+     * @fires loadgo:resume
+     */
+    resume: function () {
+      const data = $(this).data('loadgo')
+      if (typeof data === 'undefined' || !data.paused) {
+        return
+      }
+
+      const image = this[0]
+      data.paused = false
+
+      data.interval = setInterval(() => {
+        if (data.loopToggle) {
+          data.progress += 1
+          if (data.progress >= 100) {
+            data.loopToggle = false
+          }
+        } else {
+          data.progress -= 1
+          if (data.progress <= 0) {
+            data.loopToggle = true
+            dispatchCustomEvent(image, 'cycle')
+          }
+        }
+
+        if (data.overlay) {
+          data.overlay.css({ transition: 'none' })
+        }
+
+        _setprogress(image, data.progress, true)
+      }, data.loopDuration)
+
+      dispatchCustomEvent(image, 'resume', { progress: data.progress })
     },
 
     /**

--- a/packages/core/tests/loadgo-vanilla.test.js
+++ b/packages/core/tests/loadgo-vanilla.test.js
@@ -1168,3 +1168,116 @@ describe('JS - onThreshold callback', () => {
     expect(callCount).toBe(2)
   })
 })
+
+describe('JS - pause() / resume()', () => {
+  it('pause() is a no-op on an element that is not looping', () => {
+    Loadgo.init(image)
+    expect(() => Loadgo.pause(image)).not.toThrow()
+  })
+
+  it('resume() is a no-op on an element that is not paused', () => {
+    Loadgo.init(image)
+    expect(() => Loadgo.resume(image)).not.toThrow()
+  })
+
+  it('pause() stops the interval without changing progress', () => {
+    vi.useFakeTimers()
+    try {
+      Loadgo.init(image)
+      Loadgo.loop(image, 10)
+      vi.advanceTimersByTime(50)
+      const progressBeforePause = Loadgo.getprogress(image)
+      expect(progressBeforePause).toBeGreaterThan(0)
+      Loadgo.pause(image)
+      vi.advanceTimersByTime(200)
+      expect(Loadgo.getprogress(image)).toBe(progressBeforePause)
+      Loadgo.stop(image)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resume() restarts the loop from the paused progress', () => {
+    vi.useFakeTimers()
+    try {
+      Loadgo.init(image)
+      Loadgo.loop(image, 10)
+      vi.advanceTimersByTime(50)
+      const progressBeforePause = Loadgo.getprogress(image)
+      Loadgo.pause(image)
+      vi.advanceTimersByTime(50)
+      Loadgo.resume(image)
+      vi.advanceTimersByTime(10)
+      expect(Loadgo.getprogress(image)).toBeGreaterThan(progressBeforePause)
+      Loadgo.stop(image)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resume() is a no-op when called without a prior pause()', () => {
+    vi.useFakeTimers()
+    try {
+      Loadgo.init(image)
+      Loadgo.loop(image, 10)
+      vi.advanceTimersByTime(30)
+      const progressSnapshot = Loadgo.getprogress(image)
+      Loadgo.resume(image) // should not double-start
+      vi.advanceTimersByTime(10)
+      // progress should have advanced by only one tick, not two
+      expect(Loadgo.getprogress(image)).toBe(progressSnapshot + 1)
+      Loadgo.stop(image)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fires loadgo:pause event with current progress', () => {
+    vi.useFakeTimers()
+    try {
+      Loadgo.init(image)
+      Loadgo.loop(image, 10)
+      vi.advanceTimersByTime(30)
+      const { events, off } = captureEvent(image, 'loadgo:pause')
+      Loadgo.pause(image)
+      off()
+      expect(events.length).toBe(1)
+      expect(typeof events[0].detail.progress).toBe('number')
+      Loadgo.stop(image)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fires loadgo:resume event with current progress', () => {
+    vi.useFakeTimers()
+    try {
+      Loadgo.init(image)
+      Loadgo.loop(image, 10)
+      vi.advanceTimersByTime(30)
+      Loadgo.pause(image)
+      const { events, off } = captureEvent(image, 'loadgo:resume')
+      Loadgo.resume(image)
+      off()
+      expect(events.length).toBe(1)
+      expect(typeof events[0].detail.progress).toBe('number')
+      Loadgo.stop(image)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stop() after pause() still sets progress to 100', () => {
+    vi.useFakeTimers()
+    try {
+      Loadgo.init(image)
+      Loadgo.loop(image, 10)
+      vi.advanceTimersByTime(30)
+      Loadgo.pause(image)
+      Loadgo.stop(image)
+      expect(Loadgo.getprogress(image)).toBe(100)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/core/tests/loadgo.test.js
+++ b/packages/core/tests/loadgo.test.js
@@ -1139,3 +1139,115 @@ describe('jQuery - onThreshold callback', () => {
     expect(callCount).toBe(2)
   })
 })
+
+describe('jQuery - pause() / resume()', () => {
+  it('pause() is a no-op on an element that is not looping', () => {
+    $image.loadgo()
+    expect(() => $image.loadgo('pause')).not.toThrow()
+  })
+
+  it('resume() is a no-op on an element that is not paused', () => {
+    $image.loadgo()
+    expect(() => $image.loadgo('resume')).not.toThrow()
+  })
+
+  it('pause() stops the interval without changing progress', () => {
+    vi.useFakeTimers()
+    try {
+      $image.loadgo()
+      $image.loadgo('loop', 10)
+      vi.advanceTimersByTime(50)
+      const progressBeforePause = $image.loadgo('getprogress')
+      expect(progressBeforePause).toBeGreaterThan(0)
+      $image.loadgo('pause')
+      vi.advanceTimersByTime(200)
+      expect($image.loadgo('getprogress')).toBe(progressBeforePause)
+      $image.loadgo('stop')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resume() restarts the loop from the paused progress', () => {
+    vi.useFakeTimers()
+    try {
+      $image.loadgo()
+      $image.loadgo('loop', 10)
+      vi.advanceTimersByTime(50)
+      const progressBeforePause = $image.loadgo('getprogress')
+      $image.loadgo('pause')
+      vi.advanceTimersByTime(50)
+      $image.loadgo('resume')
+      vi.advanceTimersByTime(10)
+      expect($image.loadgo('getprogress')).toBeGreaterThan(progressBeforePause)
+      $image.loadgo('stop')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resume() is a no-op when called without a prior pause()', () => {
+    vi.useFakeTimers()
+    try {
+      $image.loadgo()
+      $image.loadgo('loop', 10)
+      vi.advanceTimersByTime(30)
+      const progressSnapshot = $image.loadgo('getprogress')
+      $image.loadgo('resume') // should not double-start
+      vi.advanceTimersByTime(10)
+      expect($image.loadgo('getprogress')).toBe(progressSnapshot + 1)
+      $image.loadgo('stop')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fires loadgo:pause event with current progress', () => {
+    vi.useFakeTimers()
+    try {
+      $image.loadgo()
+      $image.loadgo('loop', 10)
+      vi.advanceTimersByTime(30)
+      const { events, off } = captureEvent($image[0], 'loadgo:pause')
+      $image.loadgo('pause')
+      off()
+      expect(events.length).toBe(1)
+      expect(typeof events[0].detail.progress).toBe('number')
+      $image.loadgo('stop')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fires loadgo:resume event with current progress', () => {
+    vi.useFakeTimers()
+    try {
+      $image.loadgo()
+      $image.loadgo('loop', 10)
+      vi.advanceTimersByTime(30)
+      $image.loadgo('pause')
+      const { events, off } = captureEvent($image[0], 'loadgo:resume')
+      $image.loadgo('resume')
+      off()
+      expect(events.length).toBe(1)
+      expect(typeof events[0].detail.progress).toBe('number')
+      $image.loadgo('stop')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stop() after pause() still sets progress to 100', () => {
+    vi.useFakeTimers()
+    try {
+      $image.loadgo()
+      $image.loadgo('loop', 10)
+      vi.advanceTimersByTime(30)
+      $image.loadgo('pause')
+      $image.loadgo('stop')
+      expect($image.loadgo('getprogress')).toBe(100)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/core/types/loadgo-vanilla.d.ts
+++ b/packages/core/types/loadgo-vanilla.d.ts
@@ -75,6 +75,18 @@ export interface LoadgoAPI {
    */
   stop(element: HTMLImageElement): void
   /**
+   * Pause the loop, preserving the current progress and direction state.
+   * No-op if the element is not currently looping.
+   * @fires loadgo:pause
+   */
+  pause(element: HTMLImageElement): void
+  /**
+   * Resume a paused loop, continuing from where it left off.
+   * No-op if the element is not paused.
+   * @fires loadgo:resume
+   */
+  resume(element: HTMLImageElement): void
+  /**
    * Remove the overlay and restore the original DOM structure.
    * @fires loadgo:destroy
    */
@@ -94,8 +106,10 @@ export interface LoadgoEventMap {
   'loadgo:error': CustomEvent<{ message: string }>
   'loadgo:init': CustomEvent<null>
   'loadgo:options': CustomEvent<LoadgoOptions>
+  'loadgo:pause': CustomEvent<LoadgoDetail>
   'loadgo:progress': CustomEvent<LoadgoDetail>
   'loadgo:reset': CustomEvent<LoadgoDetail>
+  'loadgo:resume': CustomEvent<LoadgoDetail>
   'loadgo:start': CustomEvent<null>
   'loadgo:stop': CustomEvent<LoadgoDetail>
 }

--- a/packages/core/types/loadgo.d.ts
+++ b/packages/core/types/loadgo.d.ts
@@ -45,6 +45,18 @@ declare global {
      */
     loadgo(method: 'stop'): JQuery
     /**
+     * Pause the loop, preserving the current progress and direction state.
+     * No-op if the element is not currently looping.
+     * @fires loadgo:pause
+     */
+    loadgo(method: 'pause'): JQuery
+    /**
+     * Resume a paused loop, continuing from where it left off.
+     * No-op if the element is not paused.
+     * @fires loadgo:resume
+     */
+    loadgo(method: 'resume'): JQuery
+    /**
      * Remove the overlay and restore the original DOM structure.
      * @fires loadgo:destroy
      */


### PR DESCRIPTION
Related to https://github.com/franverona/loadgo/issues/43

- Added pause and resume to CUSTOM_EVENTS
- `loop()` now stores loopDuration and syncs `loopToggle` (the direction flag) into element state on each tick
- `Loadgo.pause()` /` $el.loadgo('pause')`: clears the interval, sets paused: true, fires loadgo:pause with current
  progress — no-op if not looping
- `Loadgo.resume()` / `$el.loadgo('resume')`: restarts the interval from the saved loopToggle and current progress,
  fires loadgo:resume — no-op if not paused
- Vanilla version extracts a `shared _startLoopInterval` helper to avoid code duplication between `loop()` and `resume()`

Types
- Added `pause()` and `resume()` to `LoadgoAPI` and jQuery JQuery interface
- Added `loadgo:pause` and `loadgo:resume` to `LoadgoEventMap` (typed as `CustomEvent<LoadgoDetail>`)
